### PR TITLE
feat: Move PromptReady data models into shadow-core with serde::Serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,9 @@ name = "shadow-core"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+mod prompt_inputs;
+pub use prompt_inputs::{
+    PromptReadyPersona, PromptReadyProfile, PromptReadyReasoningPolicy, PromptReadySpeechStyle,
+};
+
 pub const PROFILE_SYSTEM_PROMPT: &str = include_str!("prompts/profile_system_prompt.txt");
 pub const PREVIEW_SYSTEM_PROMPT: &str = include_str!("prompts/preview_system_prompt.txt");
 pub const CHAT_SYSTEM_PROMPT: &str = include_str!("prompts/chat_system_prompt.txt");
@@ -120,6 +125,62 @@ mod tests {
     fn shadow_locale_falls_back_to_english_for_unknown_code() {
         assert_eq!(super::ShadowLocale::from_code("de").prompt_language_name(), "English");
         assert_eq!(super::ShadowLocale::from_code("").prompt_language_name(), "English");
+    }
+
+    #[test]
+    fn prompt_ready_profile_serializes_to_expected_json() {
+        let profile = super::PromptReadyProfile {
+            headline: "Critical thinker".to_string(),
+            stance: "Pragmatic".to_string(),
+            source_answers: vec!["Answer A".to_string(), "Answer B".to_string()],
+        };
+        let value = serde_json::to_value(&profile).unwrap();
+        assert_eq!(value["headline"], "Critical thinker");
+        assert_eq!(value["stance"], "Pragmatic");
+        assert_eq!(value["source_answers"][0], "Answer A");
+        assert_eq!(value["source_answers"][1], "Answer B");
+    }
+
+    #[test]
+    fn prompt_ready_persona_without_speech_style_omits_speech_style_key() {
+        let persona = super::PromptReadyPersona {
+            tone: "Direct".to_string(),
+            traits: vec!["analytical".to_string()],
+            speech_style: None,
+        };
+        let value = serde_json::to_value(&persona).unwrap();
+        assert_eq!(value["tone"], "Direct");
+        assert!(value.get("speech_style").is_none());
+    }
+
+    #[test]
+    fn prompt_ready_persona_with_speech_style_includes_nested_object() {
+        let persona = super::PromptReadyPersona {
+            tone: "Warm".to_string(),
+            traits: vec!["empathetic".to_string()],
+            speech_style: Some(super::PromptReadySpeechStyle {
+                dialect: Some("Kansai".to_string()),
+                formality: "casual".to_string(),
+                markers: vec!["ね".to_string(), "よ".to_string()],
+                sentence_pattern: "short".to_string(),
+            }),
+        };
+        let value = serde_json::to_value(&persona).unwrap();
+        assert_eq!(value["speech_style"]["dialect"], "Kansai");
+        assert_eq!(value["speech_style"]["formality"], "casual");
+        assert_eq!(value["speech_style"]["markers"][0], "ね");
+        assert_eq!(value["speech_style"]["sentence_pattern"], "short");
+    }
+
+    #[test]
+    fn prompt_ready_reasoning_policy_serializes_to_expected_json() {
+        let policy = super::PromptReadyReasoningPolicy {
+            decision_style: "deliberate".to_string(),
+            anchor: "outcome-focused".to_string(),
+        };
+        let value = serde_json::to_value(&policy).unwrap();
+        assert_eq!(value["decision_style"], "deliberate");
+        assert_eq!(value["anchor"], "outcome-focused");
     }
 
     #[test]

--- a/src/prompt_inputs.rs
+++ b/src/prompt_inputs.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PromptReadySpeechStyle {
+    pub dialect: Option<String>,
+    pub formality: String,
+    pub markers: Vec<String>,
+    pub sentence_pattern: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PromptReadyProfile {
+    pub headline: String,
+    pub stance: String,
+    pub source_answers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PromptReadyPersona {
+    pub tone: String,
+    pub traits: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speech_style: Option<PromptReadySpeechStyle>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PromptReadyReasoningPolicy {
+    pub decision_style: String,
+    pub anchor: String,
+}


### PR DESCRIPTION
## Summary

- Add `serde` dependency with `derive` feature
- Move `PromptReadyProfile`, `PromptReadyPersona`, `PromptReadySpeechStyle`, and `PromptReadyReasoningPolicy` into a new `prompt_inputs` module
- Implement `serde::Serialize` for all four structs; `PromptReadyPersona.speech_style` uses `skip_serializing_if = "Option::is_none"` so absent speech styles are omitted from JSON output

## Test plan

- [x] 4 new unit tests cover serialization of each struct, including the `None` / `Some` speech_style cases
- [x] All 15 existing tests pass

Related: enigmatch/shadow-based-testing#372