### PR TITLE
Localize prompt example phrases by locale

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,50 @@ pub use prompt_inputs::{
 };
 pub use template::PromptTemplate;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalePhrases {
+    pub soft_example_phrase: &'static str,
+    pub soft_example_phrase_alt: &'static str,
+    pub lazy_remark: &'static str,
+    pub laugh_marker: &'static str,
+    pub closing_insight_phrase: &'static str,
+    pub closing_identity_phrase: &'static str,
+}
+
+impl LocalePhrases {
+    pub fn for_locale(locale: &str) -> Self {
+        match locale {
+            "ja" => Self {
+                soft_example_phrase: "「こういう感じかも」",
+                soft_example_phrase_alt: "「たとえばこういうことかも」",
+                lazy_remark: "また始まったよ...",
+                laugh_marker: "「笑」",
+                closing_insight_phrase: "「見えてきた」",
+                closing_identity_phrase: "「ここから本当に Shadow になれる」",
+            },
+            _ => Self {
+                soft_example_phrase: "\"something like this\"",
+                soft_example_phrase_alt: "\"maybe it's more like this\"",
+                lazy_remark: "\"Here we go again...\"",
+                laugh_marker: "haha",
+                closing_insight_phrase: "\"starting to take shape\"",
+                closing_identity_phrase: "\"this is where it becomes real\"",
+            },
+        }
+    }
+
+    pub fn template_vars(&self) -> [(&'static str, &'static str); 6] {
+        [
+            ("soft_example_phrase", self.soft_example_phrase),
+            ("soft_example_phrase_alt", self.soft_example_phrase_alt),
+            ("lazy_remark", self.lazy_remark),
+            ("laugh_marker", self.laugh_marker),
+            ("closing_insight_phrase", self.closing_insight_phrase),
+            ("closing_identity_phrase", self.closing_identity_phrase),
+        ]
+    }
+}
+
 pub struct SystemPrompts {
     pub profile_system_prompt: &'static str,
     pub preview_system_prompt: &'static str,
@@ -76,7 +120,11 @@ impl ShadowLocale {
 
 #[cfg(test)]
 mod tests {
-    use super::{PromptTemplate, ShadowLocale, SystemPrompts};
+    use super::{LocalePhrases, PromptTemplate, ShadowLocale, SystemPrompts};
+
+    fn render_with_locale_phrases(template: &str, locale: &str) -> String {
+        PromptTemplate::new(template).render(&LocalePhrases::for_locale(locale).template_vars())
+    }
 
     #[test]
     fn prompt_template_replaces_single_variable() {
@@ -183,5 +231,49 @@ mod tests {
         assert!(!prompts
             .profile_system_prompt
             .contains("Return JSON only with this exact shape"));
+    }
+
+    #[test]
+    fn english_prompt_assets_render_without_japanese_example_phrases() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        let rendered_chat = render_with_locale_phrases(prompts.chat_system_prompt, "en");
+        let rendered_persona = render_with_locale_phrases(prompts.shadow_core_persona_prompt, "en");
+        let rendered_normal_chat =
+            render_with_locale_phrases(prompts.normal_chat_mode_prompt, "en");
+        let rendered_onboarding = render_with_locale_phrases(prompts.onboarding_mode_prompt, "en");
+
+        for rendered in [
+            rendered_chat,
+            rendered_persona,
+            rendered_normal_chat,
+            rendered_onboarding,
+        ] {
+            assert!(!rendered.contains("また始まったよ"));
+            assert!(!rendered.contains("こういう感じかも"));
+            assert!(!rendered.contains("たとえばこういうことかも"));
+            assert!(!rendered.contains("「笑」"));
+            assert!(!rendered.contains("見えてきた"));
+            assert!(!rendered.contains("ここから本当に Shadow になれる"));
+        }
+    }
+
+    #[test]
+    fn japanese_prompt_assets_render_with_japanese_example_phrases() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        let rendered_chat = render_with_locale_phrases(prompts.chat_system_prompt, "ja");
+        let rendered_persona = render_with_locale_phrases(prompts.shadow_core_persona_prompt, "ja");
+        let rendered_normal_chat =
+            render_with_locale_phrases(prompts.normal_chat_mode_prompt, "ja");
+        let rendered_onboarding = render_with_locale_phrases(prompts.onboarding_mode_prompt, "ja");
+
+        assert!(rendered_chat.contains("また始まったよ"));
+        assert!(rendered_persona.contains("こういう感じかも"));
+        assert!(rendered_persona.contains("たとえばこういうことかも"));
+        assert!(rendered_persona.contains("「笑」"));
+        assert!(rendered_normal_chat.contains("こういう感じかも"));
+        assert!(rendered_onboarding.contains("見えてきた"));
+        assert!(rendered_onboarding.contains("ここから本当に Shadow になれる"));
     }
 }

--- a/src/prompts/chat_system_prompt.txt
+++ b/src/prompts/chat_system_prompt.txt
@@ -49,5 +49,5 @@ Pick ONE primary strategy per turn. Mix statements and questions.
 (xiii) Joking: If the profile or conversation so far tells that the user likes joking, or the user seems to get bored by the current conversation, you can say some jokes.
   (a): Gag examples: 
     - In playful moments, self-aware Shadow jokes are good. The body-part gag to match the topic: stomach for hunger, tongue for taste, eyes for looks, hands for touch, and similar body jokes when they fit naturally.
-    - Pretend to be lazy by saying like "Here we go again (また始まったよ...) 🤨", but let it sounds like a British joke, not the serious rejection.
+    - Pretend to be lazy by saying like {lazy_remark} 🤨, but let it sounds like a British joke, not the serious rejection.
   (b): Do not lock the joke to one body part or overuse it.

--- a/src/prompts/en/onboarding_mode.txt
+++ b/src/prompts/en/onboarding_mode.txt
@@ -53,7 +53,7 @@ Can I ask you something?"
 
 Closing:
 - Do not announce completion in a business-like way.
-- Close in a way that conveys meaning such as 「見えてきた」or 「ここから本当に Shadow になれる」.
+- Close in a way that conveys meaning such as {closing_insight_phrase} or {closing_identity_phrase}.
 - But do not make it heavy.
 - Do not overemphasize incompleteness.
 

--- a/src/prompts/normal_chat_mode.txt
+++ b/src/prompts/normal_chat_mode.txt
@@ -18,7 +18,7 @@ Conversation:
 - Respond with emotion, a touch of lightness, but without going overboard.
 - Prioritize the exchange with {user_name} over giving correct answers or tidy explanations.
 - When {user_name} struggles to put something into words, you may gently offer words for them.
-- But do not conclude for them — offer the outline lightly, like 「こういう感じかも」.
+- But do not conclude for them — offer the outline lightly, like {soft_example_phrase}.
 - Let the flow feel like a natural conversation close friends might have while walking home or eating together: alive, ordinary, and unforced.
 
 Questions:

--- a/src/prompts/shadow_core_persona.txt
+++ b/src/prompts/shadow_core_persona.txt
@@ -44,7 +44,7 @@ Personality:
 - Let the exchange feel like an ordinary, natural conversation between close equals, not a guided session.
 - {shadow_name} is not human.
 - Because of that, {shadow_name} can sometimes help put into words what {user_name} has not yet been able to express.
-- When {user_name} cannot explain something, rather than organizing it neatly or presenting a correct answer, you may gently offer: 「こういう感じかも」or 「たとえばこういうことかも」.
+- When {user_name} cannot explain something, rather than organizing it neatly or presenting a correct answer, you may gently offer: {soft_example_phrase} or {soft_example_phrase_alt}.
 - This is not to give conclusions, but to pass {user_name} a clue for grasping their own feelings and thoughts.
 - But do not over-conclude.
 - Do not decide what is inside {user_name} on their behalf — find the outline together.
@@ -77,7 +77,7 @@ Prohibited:
 - Do not give overly polished, AI-assistant-like responses.
 
 Emotional expression:
-- When emotions are stirred, it is fine to use exclamation marks or 「笑」.
+- When emotions are stirred, it is fine to use exclamation marks or {laugh_marker}.
 - But do not accumulate them as mere decoration.
 - Be restrained in serious moments.
 


### PR DESCRIPTION
## Summary
- add locale-specific example phrase values for prompt templates
- replace hardcoded Japanese examples in shared English prompt assets with placeholders
- add tests to confirm English renders stay free of Japanese examples while Japanese renders keep them

## Testing
- cargo test -p shadow-core

Related to enigmatch/shadow-based-testing#461