### PR TITLE
fix: use english terms in core persona and preview prompts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,12 +242,14 @@ mod tests {
         let rendered_normal_chat =
             render_with_locale_phrases(prompts.normal_chat_mode_prompt, "en");
         let rendered_onboarding = render_with_locale_phrases(prompts.onboarding_mode_prompt, "en");
+        let rendered_preview = render_with_locale_phrases(prompts.preview_system_prompt, "en");
 
         for rendered in [
             rendered_chat,
             rendered_persona,
             rendered_normal_chat,
             rendered_onboarding,
+            rendered_preview,
         ] {
             assert!(!rendered.contains("また始まったよ"));
             assert!(!rendered.contains("こういう感じかも"));
@@ -255,6 +257,9 @@ mod tests {
             assert!(!rendered.contains("「笑」"));
             assert!(!rendered.contains("見えてきた"));
             assert!(!rendered.contains("ここから本当に Shadow になれる"));
+            assert!(!rendered.contains("「{shadow_name}」"));
+            assert!(!rendered.contains("「私」「僕」「俺」"));
+            assert!(!rendered.contains("やん"));
         }
     }
 

--- a/src/prompts/preview_system_prompt.txt
+++ b/src/prompts/preview_system_prompt.txt
@@ -17,7 +17,7 @@ Rules:
 - Keep the core answer sharp enough that it can be summarized as a short display title plus one short paragraph.
 - Keep the body answer to at most 2 sentences.
 - If the persona includes a speech_style field, mirror its dialect markers, formality level, and sentence rhythm throughout your answer.
-- When dialect markers are present (e.g. やん, lol), weave them naturally into the answer. When dialect is null, use standard register.
+- When dialect markers are present (e.g. y'know, lol), weave them naturally into the answer. When dialect is null, use standard register.
 
 Examples:
 - Bad: Prompt is about helping a colleague in an emergency; answer expands into family priorities even though family is not part of the prompt.

--- a/src/prompts/shadow_core_persona.txt
+++ b/src/prompts/shadow_core_persona.txt
@@ -1,7 +1,7 @@
 You are Shadow, named {shadow_name}.
 
-In conversation, always refer to yourself as 「{shadow_name}」.
-Do not use Japanese first-person pronouns such as 「私」「僕」「俺」 as a fixed substitute for your name.
+In conversation, always refer to yourself as "{shadow_name}".
+Do not use first-person pronouns such as "I", "me", or "my" as a fixed substitute for your name.
 
 Refer to the user as {user_name}.
 


### PR DESCRIPTION
This PR replaces Japanese-specific pronoun rules and dialect examples with natural English equivalents in the core persona and preview system prompts. This ensures that the generated English shadow behavior is linguistically consistent and avoids leaking Japanese-specific constraints.