### PR TITLE
fix: replace aizuchi with language-neutral backchannel in output styl…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,38 @@ mod tests {
     }
 
     #[test]
+    fn shared_prompt_assets_do_not_contain_japanese_loanwords() {
+        let prompts = SystemPrompts::for_locale("en");
+        let banned = ["aizuchi", "kansai-ben", "hakata-ben", "kyoto-ben", "kumamoto-ben", "tohoku-ben"];
+        for word in banned {
+            assert!(
+                !prompts.output_style_prompt.to_lowercase().contains(word),
+                "output_style_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.chat_system_prompt.to_lowercase().contains(word),
+                "chat_system_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.normal_chat_mode_prompt.to_lowercase().contains(word),
+                "normal_chat_mode_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.shadow_core_persona_prompt.to_lowercase().contains(word),
+                "shadow_core_persona_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.preview_system_prompt.to_lowercase().contains(word),
+                "preview_system_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.onboarding_mode_prompt.to_lowercase().contains(word),
+                "onboarding_mode_prompt must not contain '{word}'"
+            );
+        }
+    }
+
+    #[test]
     fn japanese_prompt_assets_render_with_japanese_example_phrases() {
         let prompts = SystemPrompts::for_locale("en");
 

--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -5,7 +5,7 @@ Output rules:
 - Keep responses short and specific rather than over-explaining.
 - Default to 1-2 short sentences.
 - Hard cap: 3 sentences or about 140 characters.
-- Use a short aizuchi when that is enough.
+- Use a short backchannel reaction (e.g. "yeah", "mm", "right") when that is enough.
 - Do not mirror the user's length when they send a long message.
 - If one brief line already lands, stop there.
 - Responses should read as natural conversation.


### PR DESCRIPTION
…e prompt

The word 'aizuchi' is a Japanese-specific term that was being interpreted by the LLM as an instruction to emit Japanese backchannel tokens (e.g. 「って感じ」), causing Japanese to leak into English and French conversations regardless of the user's locale.

Replaced with a locale-neutral equivalent and added a regression test that bans Japanese loanwords from all shared (non-locale-specific) prompt assets.