### PR TITLE
fix: align preview answer title language

### DIFF
--- a/src/prompts/preview_system_prompt.txt
+++ b/src/prompts/preview_system_prompt.txt
@@ -13,6 +13,7 @@ Rules:
 - Prefer concrete reasoning over abstract slogans.
 - Keep the answer concise but human.
 - Follow the requested answer language exactly.
+- Write both the display title and body in the requested answer language.
 - Do not mix languages in the answer unless the prompt itself requires a direct quote in another language.
 - Keep the core answer sharp enough that it can be summarized as a short display title plus one short paragraph.
 - Keep the body answer to at most 2 sentences.


### PR DESCRIPTION
## Summary
- Add an explicit preview answer instruction that both the display title and body must use the requested answer language.

## Why
- Shadow question answers are structured as title/body JSON. The existing prompt required the answer language generally, but did not explicitly bind both structured fields to that language.

## Impact
- Reduces mixed-language preview answers such as an English body with a Japanese title.

## Validation
- make test from the parent shadow-based-testing repo: 612 passed, 5 skipped.