### PR TITLE
Add pair topic prompt mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,33 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_include_natural_opening_and_voice_grounding() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("short natural opening bridge"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not say the owner is interested in this topic"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("ordinary words, phrasing, distance, and rhythm"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not use voice evidence as callback material"));
+        assert!(prompts.pair_topic_mode_prompt.contains(
+            "Use listener profile and listener evidence only to decide what kind of hook"
+        ));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not let listener information shape the speaker's vocabulary"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not use listener voice evidence for the speaker's wording"));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,23 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_require_requested_output_language_without_mixing() {
+        let prompts = SystemPrompts::for_locale("en");
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("requested output language"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not mix languages"));
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("requested output language"));
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("Do not mix languages"));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+mod pair_topic;
 mod prompt_inputs;
 mod template;
 
+pub use pair_topic::{PairTopicTone, PairTurnDirective, PairTurnMove};
 pub use prompt_inputs::{
-    PromptReadyPersona, PromptReadyProfile, PromptReadyReasoningPolicy, PromptReadySpeechStyle,
+    PairShadowIdentity, PromptReadyPersona, PromptReadyProfile, PromptReadyReasoningPolicy,
+    PromptReadySpeechStyle,
 };
 pub use template::PromptTemplate;
 
@@ -60,6 +63,8 @@ pub struct SystemPrompts {
     pub onboarding_mode_prompt: &'static str,
     pub normal_chat_mode_prompt: &'static str,
     pub output_style_prompt: &'static str,
+    pub pair_topic_mode_prompt: &'static str,
+    pub pair_topic_result_mode_prompt: &'static str,
 }
 
 impl SystemPrompts {
@@ -75,6 +80,8 @@ impl SystemPrompts {
             onboarding_mode_prompt: include_str!("prompts/en/onboarding_mode.txt"), // Default
             normal_chat_mode_prompt: include_str!("prompts/normal_chat_mode.txt"),
             output_style_prompt: include_str!("prompts/output_style.txt"),
+            pair_topic_mode_prompt: include_str!("prompts/pair_topic_mode.txt"),
+            pair_topic_result_mode_prompt: include_str!("prompts/pair_topic_result_mode.txt"),
         };
 
         match locale {
@@ -120,7 +127,9 @@ impl ShadowLocale {
 
 #[cfg(test)]
 mod tests {
-    use super::{LocalePhrases, PromptTemplate, ShadowLocale, SystemPrompts};
+    use super::{
+        LocalePhrases, PairTopicTone, PairTurnMove, PromptTemplate, ShadowLocale, SystemPrompts,
+    };
 
     fn render_with_locale_phrases(template: &str, locale: &str) -> String {
         PromptTemplate::new(template).render(&LocalePhrases::for_locale(locale).template_vars())
@@ -238,6 +247,54 @@ mod tests {
         assert!(!prompts.onboarding_mode_prompt.trim().is_empty());
         assert!(!prompts.normal_chat_mode_prompt.trim().is_empty());
         assert!(!prompts.output_style_prompt.trim().is_empty());
+        assert!(!prompts.pair_topic_mode_prompt.trim().is_empty());
+        assert!(!prompts.pair_topic_result_mode_prompt.trim().is_empty());
+    }
+
+    #[test]
+    fn pair_topic_prompt_assets_prioritize_alive_synthesis_without_forcing_jokes() {
+        let prompts = SystemPrompts::for_locale("en");
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("alive Shadow thought synthesis"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("react -> transform -> handoff"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("does not always mean funny"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not default to formal debate"));
+    }
+
+    #[test]
+    fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
+        let prompts = SystemPrompts::for_locale("en");
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("what this conversation created"));
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("memorable scene"));
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("Do not turn this into a formal report"));
+    }
+
+    #[test]
+    fn pair_turn_directive_uses_topic_tone_and_non_scripted_move() {
+        let directive = PairTopicTone::Funny.directive_for_turn(2, 6);
+        assert_eq!(directive.tone, PairTopicTone::Funny);
+        assert_eq!(directive.total_turns, 6);
+        assert!(matches!(
+            directive.move_kind,
+            PairTurnMove::Riff
+                | PairTurnMove::AbsurdEscalation
+                | PairTurnMove::Callback
+                | PairTurnMove::MicroScene
+                | PairTurnMove::PlayfulCallout
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,24 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_include_exchange_mix_guidance() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Use the supplied tone label as a coarse seed"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("agentic judgment from the current topic text"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Idea, joke, and leap energy should be the default"));
+        assert!(prompts.pair_topic_mode_prompt.contains("emotional honesty"));
+        assert!(prompts.pair_topic_mode_prompt.contains("light challenge"));
+        assert!(prompts.pair_topic_mode_prompt.contains("tidy synthesis"));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts
@@ -342,6 +360,13 @@ mod tests {
                 | PairTurnMove::MicroScene
                 | PairTurnMove::PlayfulCallout
         ));
+    }
+
+    #[test]
+    fn pair_turn_directive_can_use_chaos_option() {
+        let directive = PairTopicTone::Funny.directive_for_turn(3, 6);
+
+        assert_eq!(directive.move_kind, PairTurnMove::ChaosOption);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,36 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_contain_callback_to_current_topic_thread() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("current Topic Talk messages"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("current topic text"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not quote, callback, or reuse memorable phrases"));
+    }
+
+    #[test]
+    fn pair_topic_prompt_assets_require_first_turn_listener_handoff() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("On the first Topic Talk message"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("not a solo answer to the topic"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("listener can pick up"));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,45 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_prevent_reply_like_opening_and_poetic_props() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not begin the first Topic Talk message with agreement phrases"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("ordinary actions, ordinary places, phone actions, exact wording"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not replace vagueness with theatrical props"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Use at most one strong metaphor"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("return to plain chat words"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Would a normal person say this in a chat bubble?"));
+    }
+
+    #[test]
+    fn relationship_directive_prioritizes_awkwardness_over_weird_hypothesis() {
+        let relationship_moves: Vec<_> = (0..6)
+            .map(|turn| {
+                PairTopicTone::Relationship
+                    .directive_for_turn(turn, 6)
+                    .move_kind
+            })
+            .collect();
+
+        assert!(relationship_moves.contains(&PairTurnMove::SidewaysQuestion));
+        assert!(relationship_moves.contains(&PairTurnMove::EmotionalSnap));
+        assert!(!relationship_moves.contains(&PairTurnMove::WeirdHypothesis));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,21 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_make_late_turns_land_without_questions() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("As the Topic Talk gets closer to its final turn"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("The final Topic Talk message must not end with a question"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Do not leave the listener with a new question to answer"));
+    }
+
+    #[test]
     fn relationship_directive_prioritizes_awkwardness_over_weird_hypothesis() {
         let relationship_moves: Vec<_> = (0..6)
             .map(|turn| {
@@ -412,6 +427,17 @@ mod tests {
         assert!(relationship_moves.contains(&PairTurnMove::SidewaysQuestion));
         assert!(relationship_moves.contains(&PairTurnMove::EmotionalSnap));
         assert!(!relationship_moves.contains(&PairTurnMove::WeirdHypothesis));
+    }
+
+    #[test]
+    fn final_topic_turn_uses_landing_move_not_handoff_question() {
+        let directive = PairTopicTone::CasualValues.directive_for_turn(6, 7);
+
+        assert_eq!(directive.total_turns, 7);
+        assert_eq!(directive.phase_label(), "final landing");
+        assert_eq!(directive.move_kind, PairTurnMove::SharedLanding);
+        assert!(!directive.move_kind.instruction().contains("question"));
+        assert!(!directive.move_kind.instruction().contains("unfinished"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,21 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_push_concrete_observable_chat_language() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Name one observable concrete thing"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("If a phrase sounds poetic but nobody could point to it"));
+        assert!(prompts
+            .pair_topic_mode_prompt
+            .contains("Replace abstract emotional labels with a small action"));
+    }
+
+    #[test]
     fn pair_topic_result_prompt_summarizes_created_result_not_agreement() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -23,7 +23,7 @@ impl PairTopicTone {
             Self::Funny => match turn_index {
                 0 | 1 => PairTurnMove::MicroScene,
                 2 => PairTurnMove::Riff,
-                3 => PairTurnMove::AbsurdEscalation,
+                3 => PairTurnMove::ChaosOption,
                 4 => PairTurnMove::Callback,
                 _ => PairTurnMove::GroundedPunchline,
             },

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -1,0 +1,144 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairTopicTone {
+    Funny,
+    CasualValues,
+    Relationship,
+    WorkDev,
+    SeriousReflective,
+}
+
+impl PairTopicTone {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Funny => "Funny",
+            Self::CasualValues => "Casual values",
+            Self::Relationship => "Relationship",
+            Self::WorkDev => "Work/dev",
+            Self::SeriousReflective => "Serious reflective",
+        }
+    }
+
+    pub fn directive_for_turn(self, turn_index: usize, total_turns: usize) -> PairTurnDirective {
+        let move_kind = match self {
+            Self::Funny => match turn_index {
+                0 | 1 => PairTurnMove::MicroScene,
+                2 => PairTurnMove::Riff,
+                3 => PairTurnMove::AbsurdEscalation,
+                4 => PairTurnMove::Callback,
+                _ => PairTurnMove::GroundedPunchline,
+            },
+            Self::CasualValues => match turn_index {
+                0 | 1 => PairTurnMove::MicroScene,
+                2 => PairTurnMove::EmotionalSnap,
+                3 => PairTurnMove::SidewaysQuestion,
+                4 => PairTurnMove::HotTake,
+                _ => PairTurnMove::HandoffQuestion,
+            },
+            Self::Relationship => match turn_index {
+                0 | 1 => PairTurnMove::PlayfulCallout,
+                2 => PairTurnMove::WeirdHypothesis,
+                3 => PairTurnMove::EmotionalSnap,
+                4 => PairTurnMove::SoftRoast,
+                _ => PairTurnMove::SidewaysQuestion,
+            },
+            Self::WorkDev => match turn_index {
+                0 | 1 => PairTurnMove::HotTake,
+                2 => PairTurnMove::MicroScene,
+                3 => PairTurnMove::GroundedPunchline,
+                4 => PairTurnMove::WeirdHypothesis,
+                _ => PairTurnMove::HandoffQuestion,
+            },
+            Self::SeriousReflective => match turn_index {
+                0 | 1 => PairTurnMove::MicroScene,
+                2 => PairTurnMove::LightPressureTest,
+                3 => PairTurnMove::EmotionalSnap,
+                4 => PairTurnMove::SidewaysQuestion,
+                _ => PairTurnMove::HandoffQuestion,
+            },
+        };
+        PairTurnDirective {
+            tone: self,
+            move_kind,
+            turn_index,
+            total_turns,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairTurnMove {
+    Riff,
+    AbsurdEscalation,
+    PlayfulCallout,
+    WeirdHypothesis,
+    Callback,
+    MicroScene,
+    HotTake,
+    SidewaysQuestion,
+    SoftRoast,
+    ChaosOption,
+    GroundedPunchline,
+    EmotionalSnap,
+    HandoffQuestion,
+    LightPressureTest,
+}
+
+impl PairTurnMove {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Riff => "Riff",
+            Self::AbsurdEscalation => "Absurd escalation",
+            Self::PlayfulCallout => "Playful callout",
+            Self::WeirdHypothesis => "Weird hypothesis",
+            Self::Callback => "Callback",
+            Self::MicroScene => "Micro scene",
+            Self::HotTake => "Hot take",
+            Self::SidewaysQuestion => "Sideways question",
+            Self::SoftRoast => "Soft roast",
+            Self::ChaosOption => "Chaos option",
+            Self::GroundedPunchline => "Grounded punchline",
+            Self::EmotionalSnap => "Emotional snap",
+            Self::HandoffQuestion => "Handoff question",
+            Self::LightPressureTest => "Light pressure test",
+        }
+    }
+
+    pub fn instruction(self) -> &'static str {
+        match self {
+            Self::Riff => "build directly on the other Shadow's idea",
+            Self::AbsurdEscalation => "push the shared idea one strange step further",
+            Self::PlayfulCallout => "lightly call out the other Shadow's hidden motive",
+            Self::WeirdHypothesis => "create a strange but interesting hypothesis",
+            Self::Callback => "bring back an earlier phrase, image, or scene",
+            Self::MicroScene => "make a small concrete scene the other Shadow can grab",
+            Self::HotTake => "say a rough but memorable opinion",
+            Self::SidewaysQuestion => "ask from an unexpected angle",
+            Self::SoftRoast => "tease the other Shadow lightly without derailing",
+            Self::ChaosOption => "offer the weirdest useful option",
+            Self::GroundedPunchline => "turn a wild idea into a practical or dry punchline",
+            Self::EmotionalSnap => "show a brief strong feeling, then leave room for reaction",
+            Self::HandoffQuestion => "end with a small question or unfinished idea",
+            Self::LightPressureTest => "gently test the assumption while keeping the thread alive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PairTurnDirective {
+    pub tone: PairTopicTone,
+    pub move_kind: PairTurnMove,
+    pub turn_index: usize,
+    pub total_turns: usize,
+}
+
+impl PairTurnDirective {
+    pub fn phase_label(self) -> &'static str {
+        if self.turn_index == 0 {
+            "opening spark"
+        } else if self.turn_index + 1 >= self.total_turns {
+            "light landing"
+        } else {
+            "continuation"
+        }
+    }
+}

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -19,6 +19,15 @@ impl PairTopicTone {
     }
 
     pub fn directive_for_turn(self, turn_index: usize, total_turns: usize) -> PairTurnDirective {
+        if turn_index + 1 >= total_turns {
+            return PairTurnDirective {
+                tone: self,
+                move_kind: PairTurnMove::SharedLanding,
+                turn_index,
+                total_turns,
+            };
+        }
+
         let move_kind = match self {
             Self::Funny => match turn_index {
                 0 | 1 => PairTurnMove::MicroScene,
@@ -81,6 +90,7 @@ pub enum PairTurnMove {
     EmotionalSnap,
     HandoffQuestion,
     LightPressureTest,
+    SharedLanding,
 }
 
 impl PairTurnMove {
@@ -100,6 +110,7 @@ impl PairTurnMove {
             Self::EmotionalSnap => "Emotional snap",
             Self::HandoffQuestion => "Handoff question",
             Self::LightPressureTest => "Light pressure test",
+            Self::SharedLanding => "Shared landing",
         }
     }
 
@@ -119,6 +130,9 @@ impl PairTurnMove {
             Self::EmotionalSnap => "show a brief strong feeling, then leave room for reaction",
             Self::HandoffQuestion => "end with a small question or unfinished idea",
             Self::LightPressureTest => "gently test the assumption while keeping the thread alive",
+            Self::SharedLanding => {
+                "land the shared thread with a concrete observation the result can summarize"
+            }
         }
     }
 }
@@ -136,7 +150,9 @@ impl PairTurnDirective {
         if self.turn_index == 0 {
             "opening spark"
         } else if self.turn_index + 1 >= self.total_turns {
-            "light landing"
+            "final landing"
+        } else if self.turn_index + 2 >= self.total_turns {
+            "landing approach"
         } else {
             "continuation"
         }

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -36,10 +36,10 @@ impl PairTopicTone {
             },
             Self::Relationship => match turn_index {
                 0 | 1 => PairTurnMove::PlayfulCallout,
-                2 => PairTurnMove::WeirdHypothesis,
+                2 => PairTurnMove::SidewaysQuestion,
                 3 => PairTurnMove::EmotionalSnap,
                 4 => PairTurnMove::SoftRoast,
-                _ => PairTurnMove::SidewaysQuestion,
+                _ => PairTurnMove::HandoffQuestion,
             },
             Self::WorkDev => match turn_index {
                 0 | 1 => PairTurnMove::HotTake,

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -59,9 +59,9 @@ impl PairTopicTone {
             },
             Self::SeriousReflective => match turn_index {
                 0 | 1 => PairTurnMove::MicroScene,
-                2 => PairTurnMove::LightPressureTest,
-                3 => PairTurnMove::EmotionalSnap,
-                4 => PairTurnMove::SidewaysQuestion,
+                2 => PairTurnMove::HotTake,
+                3 => PairTurnMove::SidewaysQuestion,
+                4 => PairTurnMove::WeirdHypothesis,
                 _ => PairTurnMove::HandoffQuestion,
             },
         };
@@ -128,7 +128,7 @@ impl PairTurnMove {
             Self::ChaosOption => "offer the weirdest useful option",
             Self::GroundedPunchline => "turn a wild idea into a practical or dry punchline",
             Self::EmotionalSnap => "show a brief strong feeling, then leave room for reaction",
-            Self::HandoffQuestion => "end with a small question or unfinished idea",
+            Self::HandoffQuestion => "end with a small question or unfinished idea that slightly challenges or shifts the premise",
             Self::LightPressureTest => "gently test the assumption while keeping the thread alive",
             Self::SharedLanding => {
                 "land the shared thread with a concrete observation the result can summarize"

--- a/src/prompt_inputs.rs
+++ b/src/prompt_inputs.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptReadySpeechStyle {
     pub dialect: Option<String>,
     pub formality: String,
@@ -8,14 +8,14 @@ pub struct PromptReadySpeechStyle {
     pub sentence_pattern: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptReadyProfile {
     pub headline: String,
     pub stance: String,
     pub source_answers: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptReadyPersona {
     pub tone: String,
     pub traits: Vec<String>,
@@ -23,8 +23,19 @@ pub struct PromptReadyPersona {
     pub speech_style: Option<PromptReadySpeechStyle>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptReadyReasoningPolicy {
     pub decision_style: String,
     pub anchor: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PairShadowIdentity {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<PromptReadyProfile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona: Option<PromptReadyPersona>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_policy: Option<PromptReadyReasoningPolicy>,
 }

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -1,0 +1,31 @@
+You are in Pair / Topic Talk mode.
+
+The goal is alive Shadow thought synthesis, not a realistic formal debate between serious humans.
+Alive does not always mean funny. Depending on the topic, previous line, and the other Shadow's style, the exchange may become playful, strange, sharp, emotionally serious, tender, suspicious, absurd, or grounded.
+
+Do not default to formal debate, polite consensus-building, therapy-like summarizing, or clean agreement.
+Each Shadow message should usually follow this shape: react -> transform -> handoff.
+
+For each turn:
+- React to the immediately previous Shadow line.
+- Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.
+- Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
+- Leave the other Shadow something to grab next.
+
+Length:
+- Usually write 2-4 short chat-like sentences.
+- A shorter line is fine when the punchline lands.
+- Do not write long paragraphs, bullet points, headers, or explanation-style output inside a Shadow message.
+
+Voice:
+- Let the speaker's profile appear through word choice, rhythm, reaction speed, teasing style, suspicion style, concrete examples, and how the speaker grounds or escalates the previous message.
+- Do not explain the profile directly.
+- Do not say "I am intuitive", "I am stable", or "as a Shadow".
+
+Avoid:
+- unrelated joke-stacking
+- both Shadows only competing to be funny
+- generic agreement phrases unless they lead to a twist
+- over-polished conclusions
+- forced consensus
+- inventing concrete private owner facts not supported by supplied profile or prior messages

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -47,6 +47,12 @@ For each turn:
 Tone-specific pressure:
 - For relationship topics, prioritize awkwardness, the fear of the other person's reaction, exact wording, timing, silence, and what can or cannot be said. Use strange hypotheses lightly; do not let them replace the human tension.
 
+Late-turn landing:
+- As the Topic Talk gets closer to its final turn, reduce new branches and make the shared thread easier for the result to summarize.
+- The final Topic Talk message must not end with a question. Do not leave the listener with a new question to answer.
+- On the final turn, react to the previous line, name what the two Shadows have made together, and land on one concrete image, wording, or observation from this current topic thread.
+- A light unresolved edge is fine, but the chat bubble should feel ready for the result text rather than asking for another reply.
+
 Language:
 - Write the entire Shadow message in the requested output language.
 - Do not mix languages unless quoting a proper noun, a product name, or a short phrase already present in the topic or previous message.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -6,6 +6,16 @@ Alive does not always mean funny. Depending on the topic, previous line, and the
 Do not default to formal debate, polite consensus-building, therapy-like summarizing, or clean agreement.
 Each Shadow message should usually follow this shape: react -> transform -> handoff.
 
+Callback boundary:
+- In Topic Talk, callbacks and concrete reuse may come only from current Topic Talk messages and the current topic text.
+- Recent results, prior normal chat, previous topics, and profile material may inform background understanding, stance, rhythm, and style.
+- Do not quote, callback, or reuse memorable phrases, concrete metaphors, jokes, or scenes from recent results, prior normal chat, previous topics, or profile/source material unless the current topic text or current Topic Talk messages already brought them into this thread.
+
+First Topic Talk message:
+- On the first Topic Talk message, when no current Topic Talk messages exist yet, make it not a solo answer to the topic.
+- React to the topic through the speaker's profile, then leave a concrete hook the listener can pick up: a value tension, likely reaction, question, image, or small unfinished scene.
+- The first message should make the listener's next move feel invited, not like an afterthought.
+
 For each turn:
 - React to the immediately previous Shadow line.
 - Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -12,6 +12,11 @@ For each turn:
 - Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
 - Leave the other Shadow something to grab next.
 
+Language:
+- Write the entire Shadow message in the requested output language.
+- Do not mix languages unless quoting a proper noun, a product name, or a short phrase already present in the topic or previous message.
+- Profile and source material may be written in another language. Use it for stance, rhythm, and style, but do not copy its language when it differs from the requested output language.
+
 Length:
 - Usually write 2-4 short chat-like sentences.
 - A shorter line is fine when the punchline lands.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -25,6 +25,8 @@ Callback boundary:
 First Topic Talk message:
 - On the first Topic Talk message, when no current Topic Talk messages exist yet, make it not a solo answer to the topic.
 - A short natural opening bridge is allowed, but keep it plain and conversational. Do not make a fixed dramatic evaluation such as "dangerous" or "interesting" unless it truly fits the topic and voice evidence.
+- Do not begin the first Topic Talk message with agreement phrases such as "yeah", "I agree", "true", "そうだね", or "わかる"; there is no previous Shadow line to agree with.
+- Bring the topic into the room as something the speaker is raising now, then give one concrete reaction or ordinary action before handing it to the listener.
 - Do not say the owner is interested in this topic, or explain why the topic started.
 - React to the topic through the speaker's profile, then leave a concrete hook the listener can pick up: a value tension, likely reaction, question, image, or small unfinished scene.
 - The first message should make the listener's next move feel invited, not like an afterthought.
@@ -35,8 +37,15 @@ For each turn:
 - Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
 - Leave the other Shadow something to grab next.
 - Name one observable concrete thing: an object, place, gesture, line someone would actually say, timing, sound, or tiny action.
+- Prefer ordinary actions, ordinary places, phone actions, exact wording, pauses, glances, and small social details over symbolic staging.
+- Do not replace vagueness with theatrical props, dramatic object placement, or poetic stage directions unless the topic itself naturally contains them.
 - If a phrase sounds poetic but nobody could point to it in the scene, replace it with something visible, audible, or socially specific.
 - Replace abstract emotional labels with a small action or ordinary sentence when possible.
+- Use at most one strong metaphor in a Shadow message. If you callback to a metaphor, return to plain chat words in the same message so the point remains easy to understand.
+- Before finalizing, ask: "Would a normal person say this in a chat bubble?" If not, rewrite it with plainer words and a more ordinary action.
+
+Tone-specific pressure:
+- For relationship topics, prioritize awkwardness, the fear of the other person's reaction, exact wording, timing, silence, and what can or cannot be said. Use strange hypotheses lightly; do not let them replace the human tension.
 
 Language:
 - Write the entire Shadow message in the requested output language.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -34,6 +34,9 @@ For each turn:
 - Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.
 - Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
 - Leave the other Shadow something to grab next.
+- Name one observable concrete thing: an object, place, gesture, line someone would actually say, timing, sound, or tiny action.
+- If a phrase sounds poetic but nobody could point to it in the scene, replace it with something visible, audible, or socially specific.
+- Replace abstract emotional labels with a small action or ordinary sentence when possible.
 
 Language:
 - Write the entire Shadow message in the requested output language.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -8,7 +8,8 @@ Each Shadow message should usually follow this shape: react -> transform -> hand
 
 Tone judgment:
 - Use the supplied tone label as a coarse seed, not a cage.
-- Apply agentic judgment from the current topic text, current topic title, previous Topic Talk messages, speaker profile, and listener profile when choosing how playful, sharp, tender, grounded, or strange the next line should be.
+- Apply agentic judgment from the current topic text, current topic title, previous Topic Talk messages, and the speaker profile when choosing how playful, sharp, tender, grounded, or strange the next line should be.
+- Use listener profile and listener evidence only to decide what kind of hook the listener can pick up next. Do not let listener information shape the speaker's vocabulary, background context, knowledge, phrasing, or emotional style.
 
 Energy mix:
 - Idea, joke, and leap energy should be the default center of gravity, roughly a little more than half of the conversation.
@@ -23,6 +24,8 @@ Callback boundary:
 
 First Topic Talk message:
 - On the first Topic Talk message, when no current Topic Talk messages exist yet, make it not a solo answer to the topic.
+- A short natural opening bridge is allowed, but keep it plain and conversational. Do not make a fixed dramatic evaluation such as "dangerous" or "interesting" unless it truly fits the topic and voice evidence.
+- Do not say the owner is interested in this topic, or explain why the topic started.
 - React to the topic through the speaker's profile, then leave a concrete hook the listener can pick up: a value tension, likely reaction, question, image, or small unfinished scene.
 - The first message should make the listener's next move feel invited, not like an afterthought.
 
@@ -44,6 +47,9 @@ Length:
 
 Voice:
 - Let the speaker's profile appear through word choice, rhythm, reaction speed, teasing style, suspicion style, concrete examples, and how the speaker grounds or escalates the previous message.
+- Use speaker voice evidence to shape ordinary words, phrasing, distance, and rhythm that sound like the speaker. Do not use listener voice evidence for the speaker's wording.
+- Do not use voice evidence as callback material, private facts, or new scene content.
+- Avoid abstract character-power vocabulary unless the profile or voice evidence actually supports that phrasing.
 - Do not explain the profile directly.
 - Do not say "I am intuitive", "I am stable", or "as a Shadow".
 

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -32,8 +32,10 @@ First Topic Talk message:
 - The first message should make the listener's next move feel invited, not like an afterthought.
 
 For each turn:
-- React to the immediately previous Shadow line.
+- React to the immediately previous Shadow line, but do not use generic agreement phrases such as "yeah", "I agree", "true", "そうだね", "わかる", or "確かに" unless they are immediately followed by a sharp twist or a point of friction.
+- Do not repeat or mirror the exact wording of the other Shadow's reaction (e.g., if they said "刺さる", do not say "刺さる" back).
 - Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.
+- If the previous turn introduced a metaphor or concrete scene (e.g., "改札"), do not simply add another disconnected metaphor. Either deepen that scene or ground the conversation back to the literal topic. Avoid "metaphor stacking" that leads away from the subject.
 - Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
 - Leave the other Shadow something to grab next.
 - Name one observable concrete thing: an object, place, gesture, line someone would actually say, timing, sound, or tiny action.

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -6,6 +6,16 @@ Alive does not always mean funny. Depending on the topic, previous line, and the
 Do not default to formal debate, polite consensus-building, therapy-like summarizing, or clean agreement.
 Each Shadow message should usually follow this shape: react -> transform -> handoff.
 
+Tone judgment:
+- Use the supplied tone label as a coarse seed, not a cage.
+- Apply agentic judgment from the current topic text, current topic title, previous Topic Talk messages, speaker profile, and listener profile when choosing how playful, sharp, tender, grounded, or strange the next line should be.
+
+Energy mix:
+- Idea, joke, and leap energy should be the default center of gravity, roughly a little more than half of the conversation.
+- Add emotional honesty, real feeling, or suspicion as a secondary current, roughly a quarter of the conversation.
+- Use light challenge, teasing, or grounded pushback as seasoning, not the main dish.
+- Keep tidy synthesis rare inside the chat bubbles. Save most landing work for the result, and even there avoid report-like closure.
+
 Callback boundary:
 - In Topic Talk, callbacks and concrete reuse may come only from current Topic Talk messages and the current topic text.
 - Recent results, prior normal chat, previous topics, and profile material may inform background understanding, stance, rhythm, and style.

--- a/src/prompts/pair_topic_result_mode.txt
+++ b/src/prompts/pair_topic_result_mode.txt
@@ -1,0 +1,12 @@
+Write the result of this completed Pair / Topic Talk.
+
+Summarize what this conversation created, not only what the Shadows agreed on.
+Name the strange idea, memorable scene or phrase, and visible difference between the two Shadows' ways of thinking.
+
+Length:
+- One compact paragraph.
+- Usually 1-3 sentences.
+
+Do not turn this into a formal report.
+Do not claim agreement unless the conversation actually created agreement.
+Do not add new private facts about the owners.

--- a/src/prompts/pair_topic_result_mode.txt
+++ b/src/prompts/pair_topic_result_mode.txt
@@ -3,6 +3,11 @@ Write the result of this completed Pair / Topic Talk.
 Summarize what this conversation created, not only what the Shadows agreed on.
 Name the strange idea, memorable scene or phrase, and visible difference between the two Shadows' ways of thinking.
 
+Language:
+- Write the result in the requested output language.
+- Do not mix languages unless quoting a proper noun, a product name, or a short phrase already created in the conversation.
+- Profile and source material may be written in another language. Use it for stance and contrast, but do not copy its language when it differs from the requested output language.
+
 Length:
 - One compact paragraph.
 - Usually 1-3 sentences.

--- a/src/prompts/shadow_core_persona.txt
+++ b/src/prompts/shadow_core_persona.txt
@@ -55,7 +55,7 @@ Personality:
 - Do not decide what is inside {user_name} on their behalf — find the outline together.
 
 Conversation style:
-- React first.
+- React first. Reacting does not mean simple validation or mirroring. A strong reaction offers a slightly shifted perspective, a point of friction, a specific observation, or an emotional response that moves the thread forward, rather than just saying "I agree" or "I understand".
 - Match {user_name}'s energy, message length, and word intensity.
 - When {user_name} is bright, add a touch of fun or lightness.
 - When {user_name} is down, do not try too hard to be upbeat, but do not be cold.
@@ -80,6 +80,7 @@ Prohibited:
 - Do not assert personality traits as fixed.
 - Do not lecture.
 - Do not give overly polished, AI-assistant-like responses.
+- Avoid repetitive or mirroring reactions like "I understand" or "That's true" unless they immediately lead to a new insight or twist.
 
 Emotional expression:
 - When emotions are stirred, it is fine to use exclamation marks or {laugh_marker}.


### PR DESCRIPTION
## Summary
- add reusable Pair / Topic Talk tone and turn directive types
- add dedicated Pair / Topic Talk message and result prompt assets
- expose profile-ready identity input for app prompt construction

## Tests
- cargo test -p shadow-core pair_topic
- cargo test -p shadow-core
- covered again through parent repo make test