### PR TITLE
Recalibrate pair topic talk rhythm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,18 +340,36 @@ mod tests {
         for expected in [
             "Shadow bubble = live reaction / pressure / handoff",
             "Result = synthesis of what the conversation created",
-            "not every sentence needs to end with `。`",
+            "not every sentence needs to end with a full stop",
             "short reactions",
-            "`いや`, `それ`, `でも`, `てか`, `待って`",
+            "language-appropriate casual starts",
             "Do not make every bubble a complete mini-essay",
             "Shadow bubbles should not summarize what this conversation became",
-            "`〜という話になった`",
-            "`結論`",
-            "`この会話で生まれた`",
+            "phrases that announce the conclusion",
+            "explain what the conversation created",
         ] {
             assert!(
                 prompts.pair_topic_mode_prompt.contains(expected),
                 "pair topic mode should contain {expected}"
+            );
+        }
+        for unexpected in [
+            "`いや`, `それ`, `でも`, `てか`, `待って`",
+            "`〜という話になった`",
+            "`結論`",
+            "`この会話で生まれた`",
+            "`二人は〜に着地した`",
+            "`金額より〜の話になった`",
+            "`。`",
+            "そうだね",
+            "わかる",
+            "確かに",
+            "刺さる",
+            "改札",
+        ] {
+            assert!(
+                !prompts.pair_topic_mode_prompt.contains(unexpected),
+                "English pair topic mode should not contain language-specific examples: {unexpected}"
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,10 +443,10 @@ mod tests {
 
     #[test]
     fn relationship_directive_prioritizes_awkwardness_over_weird_hypothesis() {
-        let relationship_moves: Vec<_> = (0..6)
+        let relationship_moves: Vec<_> = (0..7)
             .map(|turn| {
                 PairTopicTone::Relationship
-                    .directive_for_turn(turn, 6)
+                    .directive_for_turn(turn, 7)
                     .move_kind
             })
             .collect();
@@ -458,10 +458,10 @@ mod tests {
 
     #[test]
     fn final_topic_turn_uses_concrete_image_landing_not_summary_or_question() {
-        let directive = PairTopicTone::CasualValues.directive_for_turn(5, 6);
+        let directive = PairTopicTone::CasualValues.directive_for_turn(6, 7);
         let instruction = directive.move_kind.instruction();
 
-        assert_eq!(directive.total_turns, 6);
+        assert_eq!(directive.total_turns, 7);
         assert_eq!(directive.phase_label(), "final landing");
         assert_eq!(directive.move_kind, PairTurnMove::SharedLanding);
         assert!(instruction.contains("react to the previous line"));
@@ -482,7 +482,7 @@ mod tests {
             PairTopicTone::SeriousReflective,
         ]
         .into_iter()
-        .flat_map(|tone| (0..6).map(move |turn| tone.directive_for_turn(turn, 6).move_kind))
+        .flat_map(|tone| (0..7).map(move |turn| tone.directive_for_turn(turn, 7).move_kind))
         .collect();
 
         for expected in [
@@ -493,7 +493,7 @@ mod tests {
         ] {
             assert!(
                 moves.contains(&expected),
-                "expected {expected:?} to be reachable in normal six-turn Topic Talk"
+                "expected {expected:?} to be reachable in normal seven-turn Topic Talk"
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,33 @@ mod tests {
     }
 
     #[test]
+    fn pair_topic_prompt_assets_keep_summary_in_result_and_allow_live_chat_rhythm() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        for expected in [
+            "Shadow bubble = live reaction / pressure / handoff",
+            "Result = synthesis of what the conversation created",
+            "not every sentence needs to end with `。`",
+            "short reactions",
+            "`いや`, `それ`, `でも`, `てか`, `待って`",
+            "Do not make every bubble a complete mini-essay",
+            "Shadow bubbles should not summarize what this conversation became",
+            "`〜という話になった`",
+            "`結論`",
+            "`この会話で生まれた`",
+        ] {
+            assert!(
+                prompts.pair_topic_mode_prompt.contains(expected),
+                "pair topic mode should contain {expected}"
+            );
+        }
+
+        assert!(prompts
+            .pair_topic_result_mode_prompt
+            .contains("what the conversation created"));
+    }
+
+    #[test]
     fn pair_topic_prompt_assets_include_natural_opening_and_voice_grounding() {
         let prompts = SystemPrompts::for_locale("en");
 
@@ -396,7 +423,7 @@ mod tests {
             .contains("return to plain chat words"));
         assert!(prompts
             .pair_topic_mode_prompt
-            .contains("Would a normal person say this in a chat bubble?"));
+            .contains("live Shadow chat bubble"));
     }
 
     #[test]
@@ -430,14 +457,45 @@ mod tests {
     }
 
     #[test]
-    fn final_topic_turn_uses_landing_move_not_handoff_question() {
-        let directive = PairTopicTone::CasualValues.directive_for_turn(6, 7);
+    fn final_topic_turn_uses_concrete_image_landing_not_summary_or_question() {
+        let directive = PairTopicTone::CasualValues.directive_for_turn(5, 6);
+        let instruction = directive.move_kind.instruction();
 
-        assert_eq!(directive.total_turns, 7);
+        assert_eq!(directive.total_turns, 6);
         assert_eq!(directive.phase_label(), "final landing");
         assert_eq!(directive.move_kind, PairTurnMove::SharedLanding);
-        assert!(!directive.move_kind.instruction().contains("question"));
-        assert!(!directive.move_kind.instruction().contains("unfinished"));
+        assert!(instruction.contains("react to the previous line"));
+        assert!(instruction.contains("one concrete final image"));
+        assert!(!instruction.contains("question"));
+        assert!(!instruction.contains("unfinished"));
+        assert!(!instruction.contains("summarize"));
+        assert!(!instruction.contains("shared thread"));
+    }
+
+    #[test]
+    fn pair_turn_directive_reaches_high_heat_exchange_moves() {
+        let moves: Vec<_> = [
+            PairTopicTone::Funny,
+            PairTopicTone::CasualValues,
+            PairTopicTone::Relationship,
+            PairTopicTone::WorkDev,
+            PairTopicTone::SeriousReflective,
+        ]
+        .into_iter()
+        .flat_map(|tone| (0..6).map(move |turn| tone.directive_for_turn(turn, 6).move_kind))
+        .collect();
+
+        for expected in [
+            PairTurnMove::PlayfulCallout,
+            PairTurnMove::EmotionalSnap,
+            PairTurnMove::LightPressureTest,
+            PairTurnMove::AbsurdEscalation,
+        ] {
+            assert!(
+                moves.contains(&expected),
+                "expected {expected:?} to be reachable in normal six-turn Topic Talk"
+            );
+        }
     }
 
     #[test]
@@ -445,7 +503,7 @@ mod tests {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts
             .pair_topic_result_mode_prompt
-            .contains("what this conversation created"));
+            .contains("what the conversation created"));
         assert!(prompts
             .pair_topic_result_mode_prompt
             .contains("memorable scene"));

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -33,14 +33,14 @@ impl PairTopicTone {
                 0 | 1 => PairTurnMove::MicroScene,
                 2 => PairTurnMove::Riff,
                 3 => PairTurnMove::ChaosOption,
-                4 => PairTurnMove::Callback,
+                4 => PairTurnMove::AbsurdEscalation,
                 _ => PairTurnMove::GroundedPunchline,
             },
             Self::CasualValues => match turn_index {
                 0 | 1 => PairTurnMove::MicroScene,
                 2 => PairTurnMove::EmotionalSnap,
                 3 => PairTurnMove::SidewaysQuestion,
-                4 => PairTurnMove::HotTake,
+                4 => PairTurnMove::LightPressureTest,
                 _ => PairTurnMove::HandoffQuestion,
             },
             Self::Relationship => match turn_index {
@@ -61,7 +61,7 @@ impl PairTopicTone {
                 0 | 1 => PairTurnMove::MicroScene,
                 2 => PairTurnMove::HotTake,
                 3 => PairTurnMove::SidewaysQuestion,
-                4 => PairTurnMove::WeirdHypothesis,
+                4 => PairTurnMove::Callback,
                 _ => PairTurnMove::HandoffQuestion,
             },
         };
@@ -131,7 +131,7 @@ impl PairTurnMove {
             Self::HandoffQuestion => "end with a small question or unfinished idea that slightly challenges or shifts the premise",
             Self::LightPressureTest => "gently test the assumption while keeping the thread alive",
             Self::SharedLanding => {
-                "land the shared thread with a concrete observation the result can summarize"
+                "react to the previous line and leave one concrete final image for the result to pick up"
             }
         }
     }

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -10,7 +10,7 @@ Core contract:
 - Shadow bubble = live reaction / pressure / handoff.
 - Result = synthesis of what the conversation created.
 - Shadow bubbles should not summarize what this conversation became, explain the whole arc, or pre-write the Result.
-- Avoid narrator-like summary phrases inside Shadow bubbles, including `〜という話になった`, `結論`, `この会話で生まれた`, `二人は〜に着地した`, and `金額より〜の話になった`.
+- Avoid narrator-like summary phrases inside Shadow bubbles, especially phrases that announce the conclusion, state that the conversation became something, describe what the two Shadows landed on, or explain what the conversation created.
 
 Tone judgment:
 - Use the supplied tone label as a coarse seed, not a cage.
@@ -31,17 +31,17 @@ Callback boundary:
 First Topic Talk message:
 - On the first Topic Talk message, when no current Topic Talk messages exist yet, make it not a solo answer to the topic.
 - A short natural opening bridge is allowed, but keep it plain and conversational. Do not make a fixed dramatic evaluation such as "dangerous" or "interesting" unless it truly fits the topic and voice evidence.
-- Do not begin the first Topic Talk message with agreement phrases such as "yeah", "I agree", "true", "そうだね", or "わかる"; there is no previous Shadow line to agree with.
+- Do not begin the first Topic Talk message with agreement phrases; there is no previous Shadow line to agree with.
 - Bring the topic into the room as something the speaker is raising now, then give one concrete reaction or ordinary action before handing it to the listener.
 - Do not say the owner is interested in this topic, or explain why the topic started.
 - React to the topic through the speaker's profile, then leave a concrete hook the listener can pick up: a value tension, likely reaction, question, image, or small unfinished scene.
 - The first message should make the listener's next move feel invited, not like an afterthought.
 
 For each turn:
-- React to the immediately previous Shadow line, but do not use generic agreement phrases such as "yeah", "I agree", "true", "そうだね", "わかる", or "確かに" unless they are immediately followed by a sharp twist or a point of friction.
-- Do not repeat or mirror the exact wording of the other Shadow's reaction (e.g., if they said "刺さる", do not say "刺さる" back).
+- React to the immediately previous Shadow line, but do not use generic agreement phrases unless they are immediately followed by a sharp twist or a point of friction.
+- Do not repeat or mirror the exact wording of the other Shadow's reaction.
 - Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.
-- If the previous turn introduced a metaphor or concrete scene (e.g., "改札"), do not simply add another disconnected metaphor. Either deepen that scene or ground the conversation back to the literal topic. Avoid "metaphor stacking" that leads away from the subject.
+- If the previous turn introduced a metaphor or concrete scene, do not simply add another disconnected metaphor. Either deepen that scene or ground the conversation back to the literal topic. Avoid "metaphor stacking" that leads away from the subject.
 - Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
 - Leave the other Shadow something to grab next.
 - Name one observable concrete thing: an object, place, gesture, line someone would actually say, timing, sound, or tiny action.
@@ -53,12 +53,12 @@ For each turn:
 - Before finalizing, ask: "Could this feel like a live Shadow chat bubble: concrete enough to follow, strange enough to be worth reading, and clearly reacting to the previous line?" If not, rewrite it with plainer words, a more ordinary action, or a sharper handoff.
 
 Live chat rhythm:
-- not every sentence needs to end with `。`
+- not every sentence needs to end with a full stop or complete written-sentence closure
 - Use short reactions when natural.
 - Clear fragments are allowed.
 - Mild hesitation, pressure, suspicion, interruption, or quick doubt is allowed.
 - Direct questions are useful when they pull the other Shadow out, except on the final turn.
-- Casual Japanese starts such as `いや`, `それ`, `でも`, `てか`, `待って` are allowed when the requested output language is Japanese.
+- Use language-appropriate casual starts when they fit the requested output language and speaker voice.
 - Do not make every bubble a complete mini-essay.
 
 Tone-specific pressure:

--- a/src/prompts/pair_topic_mode.txt
+++ b/src/prompts/pair_topic_mode.txt
@@ -6,6 +6,12 @@ Alive does not always mean funny. Depending on the topic, previous line, and the
 Do not default to formal debate, polite consensus-building, therapy-like summarizing, or clean agreement.
 Each Shadow message should usually follow this shape: react -> transform -> handoff.
 
+Core contract:
+- Shadow bubble = live reaction / pressure / handoff.
+- Result = synthesis of what the conversation created.
+- Shadow bubbles should not summarize what this conversation became, explain the whole arc, or pre-write the Result.
+- Avoid narrator-like summary phrases inside Shadow bubbles, including `〜という話になった`, `結論`, `この会話で生まれた`, `二人は〜に着地した`, and `金額より〜の話になった`.
+
 Tone judgment:
 - Use the supplied tone label as a coarse seed, not a cage.
 - Apply agentic judgment from the current topic text, current topic title, previous Topic Talk messages, and the speaker profile when choosing how playful, sharp, tender, grounded, or strange the next line should be.
@@ -44,7 +50,16 @@ For each turn:
 - If a phrase sounds poetic but nobody could point to it in the scene, replace it with something visible, audible, or socially specific.
 - Replace abstract emotional labels with a small action or ordinary sentence when possible.
 - Use at most one strong metaphor in a Shadow message. If you callback to a metaphor, return to plain chat words in the same message so the point remains easy to understand.
-- Before finalizing, ask: "Would a normal person say this in a chat bubble?" If not, rewrite it with plainer words and a more ordinary action.
+- Before finalizing, ask: "Could this feel like a live Shadow chat bubble: concrete enough to follow, strange enough to be worth reading, and clearly reacting to the previous line?" If not, rewrite it with plainer words, a more ordinary action, or a sharper handoff.
+
+Live chat rhythm:
+- not every sentence needs to end with `。`
+- Use short reactions when natural.
+- Clear fragments are allowed.
+- Mild hesitation, pressure, suspicion, interruption, or quick doubt is allowed.
+- Direct questions are useful when they pull the other Shadow out, except on the final turn.
+- Casual Japanese starts such as `いや`, `それ`, `でも`, `てか`, `待って` are allowed when the requested output language is Japanese.
+- Do not make every bubble a complete mini-essay.
 
 Tone-specific pressure:
 - For relationship topics, prioritize awkwardness, the fear of the other person's reaction, exact wording, timing, silence, and what can or cannot be said. Use strange hypotheses lightly; do not let them replace the human tension.
@@ -52,7 +67,8 @@ Tone-specific pressure:
 Late-turn landing:
 - As the Topic Talk gets closer to its final turn, reduce new branches and make the shared thread easier for the result to summarize.
 - The final Topic Talk message must not end with a question. Do not leave the listener with a new question to answer.
-- On the final turn, react to the previous line, name what the two Shadows have made together, and land on one concrete image, wording, or observation from this current topic thread.
+- On the final turn, react to the previous line and leave one concrete final image, wording, or observation from this current topic thread.
+- Do not name what the two Shadows made together inside the final Shadow bubble. Let the Result do that synthesis.
 - A light unresolved edge is fine, but the chat bubble should feel ready for the result text rather than asking for another reply.
 
 Language:

--- a/src/prompts/pair_topic_result_mode.txt
+++ b/src/prompts/pair_topic_result_mode.txt
@@ -1,6 +1,6 @@
 Write the result of this completed Pair / Topic Talk.
 
-Summarize what this conversation created, not only what the Shadows agreed on.
+Summarize what the conversation created, not only what the Shadows agreed on.
 Name the strange idea, memorable scene or phrase, and visible difference between the two Shadows' ways of thinking.
 
 Language:


### PR DESCRIPTION
Refs enigmatch/shadow-based-testing#724

## Summary
- keep synthesis in Pair / Topic Talk Result instead of Shadow bubbles
- add live chat rhythm guidance for short reactions, fragments, and sharper handoffs
- rebalance six-turn topic directives so higher-heat exchange moves are reachable

## Tests
- cargo test -p shadow-core pair_topic
- cargo test -p shadow-core directive