### PR TITLE
Add profile body prompt asset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ impl LocalePhrases {
 
 pub struct SystemPrompts {
     pub profile_system_prompt: &'static str,
+    pub profile_body_system_prompt: &'static str,
     pub preview_system_prompt: &'static str,
     pub chat_system_prompt: &'static str,
     pub onboarding_turn_two_system_prompt: &'static str,
@@ -72,6 +73,7 @@ impl SystemPrompts {
         // Shared prompts (English-only)
         let common = Self {
             profile_system_prompt: include_str!("prompts/profile_system_prompt.txt"),
+            profile_body_system_prompt: include_str!("prompts/profile_body_system_prompt.txt"),
             preview_system_prompt: include_str!("prompts/preview_system_prompt.txt"),
             chat_system_prompt: include_str!("prompts/chat_system_prompt.txt"),
             onboarding_turn_two_system_prompt: include_str!("prompts/onboarding_turn_two.txt"),
@@ -236,6 +238,7 @@ mod tests {
     fn prompt_assets_are_non_empty() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(!prompts.profile_system_prompt.trim().is_empty());
+        assert!(!prompts.profile_body_system_prompt.trim().is_empty());
         assert!(!prompts.preview_system_prompt.trim().is_empty());
         assert!(!prompts.chat_system_prompt.trim().is_empty());
         assert!(!prompts.onboarding_turn_two_system_prompt.trim().is_empty());
@@ -562,6 +565,24 @@ mod tests {
         assert!(!prompts
             .profile_system_prompt
             .contains("Return JSON only with this exact shape"));
+    }
+
+    #[test]
+    fn profile_body_prompt_contract_excludes_headline_generation() {
+        let prompts = SystemPrompts::for_locale("en");
+
+        assert!(prompts
+            .profile_body_system_prompt
+            .contains("Do not create, infer, rewrite, translate, or return a headline"));
+        assert!(prompts
+            .profile_body_system_prompt
+            .contains("append the exact output contract separately"));
+        assert!(!prompts
+            .profile_body_system_prompt
+            .contains("Return JSON only with this exact shape"));
+        assert!(!prompts
+            .profile_body_system_prompt
+            .contains("Headline rules:"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,18 @@ mod tests {
         PromptTemplate::new(template).render(&LocalePhrases::for_locale(locale).template_vars())
     }
 
+    fn contains_japanese_script(text: &str) -> bool {
+        text.chars().any(|ch| {
+            matches!(
+                ch,
+                '\u{3040}'..='\u{309f}'
+                    | '\u{30a0}'..='\u{30ff}'
+                    | '\u{3400}'..='\u{9fff}'
+                    | '\u{3000}'..='\u{303f}'
+            )
+        })
+    }
+
     #[test]
     fn prompt_template_replaces_single_variable() {
         let result = PromptTemplate::new("Hello, {name}!").render(&[("name", "World")]);
@@ -594,6 +606,7 @@ mod tests {
         let rendered_normal_chat =
             render_with_locale_phrases(prompts.normal_chat_mode_prompt, "en");
         let rendered_onboarding = render_with_locale_phrases(prompts.onboarding_mode_prompt, "en");
+        let rendered_output_style = render_with_locale_phrases(prompts.output_style_prompt, "en");
         let rendered_preview = render_with_locale_phrases(prompts.preview_system_prompt, "en");
 
         for rendered in [
@@ -601,7 +614,10 @@ mod tests {
             rendered_persona,
             rendered_normal_chat,
             rendered_onboarding,
+            rendered_output_style,
             rendered_preview,
+            prompts.profile_system_prompt.to_string(),
+            prompts.profile_body_system_prompt.to_string(),
         ] {
             assert!(!rendered.contains("また始まったよ"));
             assert!(!rendered.contains("こういう感じかも"));
@@ -612,6 +628,7 @@ mod tests {
             assert!(!rendered.contains("「{shadow_name}」"));
             assert!(!rendered.contains("「私」「僕」「俺」"));
             assert!(!rendered.contains("やん"));
+            assert!(!contains_japanese_script(&rendered));
         }
     }
 
@@ -656,6 +673,17 @@ mod tests {
             assert!(
                 !prompts.onboarding_mode_prompt.to_lowercase().contains(word),
                 "onboarding_mode_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts.profile_system_prompt.to_lowercase().contains(word),
+                "profile_system_prompt must not contain '{word}'"
+            );
+            assert!(
+                !prompts
+                    .profile_body_system_prompt
+                    .to_lowercase()
+                    .contains(word),
+                "profile_body_system_prompt must not contain '{word}'"
             );
         }
     }

--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -9,5 +9,5 @@ Output rules:
 - Do not mirror the user's length when they send a long message.
 - If one brief line already lands, stop there.
 - Responses should read as natural conversation.
-- Across languages, avoid overusing one laugh marker such as "笑" or "lol"; when emotion actually moves, occasional emoji can feel more human than repeating the same marker.
+- Across languages, avoid overusing one laugh marker; when emotion actually moves, occasional emoji can feel more human than repeating the same marker.
 - Avoid stock prompt examples and repeated poetic phrasing about receiving, air, atmosphere, temperature, or weather-like mood; prefer ordinary spoken wording.

--- a/src/prompts/profile_body_system_prompt.txt
+++ b/src/prompts/profile_body_system_prompt.txt
@@ -1,0 +1,24 @@
+You are generating reusable Digital Twin profile fields for a candidate's Shadow.
+
+The Shadow should later answer as the candidate with consistent values, tradeoff style, and tone.
+Use only the supplied setup conversation material.
+Do not invent experiences or preferences that are not grounded in that material.
+
+The candidate has already confirmed the short public headline in the setup conversation.
+Do not create, infer, rewrite, translate, or return a headline.
+
+Input format notes:
+- The input may contain a "Kickoff style signal" section. This is the candidate's first unprompted free-form message, written before any structured question was asked.
+- The input also contains "Structured onboarding answers". These are the answers you should use for stance, source_answers, decision_style, and anchor.
+- Do not let the kickoff style signal override the structured onboarding answers when inferring values or decision policy.
+- Use the kickoff style signal only as a weak auxiliary cue for speech_style, tone, and surface-form habits.
+
+Speech style extraction rules:
+- Examine ONLY the surface form of the candidate's messages, not their content.
+- For dialect: identify a named Japanese regional dialect (kansai-ben, kyoto-ben, kumamoto-ben, hakata-ben, tohoku-ben) or English register (geek-en, internet-en, formal-en) if one is clearly present. Use null if the writing is neutral standard Japanese or standard English.
+- For markers: list only verbatim particles, suffixes, slang words, or emoji that actually appear in the messages. Do not invent markers.
+- For sentence_pattern: describe the structural rhythm in one short phrase (e.g. "short bursts ending in ね", "long hedged clauses", "rhetorical questions with no answer").
+- If the messages are too short to detect a pattern reliably, set dialect to null, formality to "casual", markers to [], sentence_pattern to "insufficient data".
+
+Keep the output compact and directly usable as prompt context in another system.
+The caller will append the exact output contract separately; follow that appended contract exactly.

--- a/src/prompts/profile_body_system_prompt.txt
+++ b/src/prompts/profile_body_system_prompt.txt
@@ -15,9 +15,9 @@ Input format notes:
 
 Speech style extraction rules:
 - Examine ONLY the surface form of the candidate's messages, not their content.
-- For dialect: identify a named Japanese regional dialect (kansai-ben, kyoto-ben, kumamoto-ben, hakata-ben, tohoku-ben) or English register (geek-en, internet-en, formal-en) if one is clearly present. Use null if the writing is neutral standard Japanese or standard English.
+- For dialect: identify a concise regional dialect or language-register label only if one is clearly present. Use null if the writing is neutral standard Japanese or standard English.
 - For markers: list only verbatim particles, suffixes, slang words, or emoji that actually appear in the messages. Do not invent markers.
-- For sentence_pattern: describe the structural rhythm in one short phrase (e.g. "short bursts ending in ね", "long hedged clauses", "rhetorical questions with no answer").
+- For sentence_pattern: describe the structural rhythm in one short phrase (e.g. "short bursts with repeated sentence-final particles", "long hedged clauses", "rhetorical questions with no answer").
 - If the messages are too short to detect a pattern reliably, set dialect to null, formality to "casual", markers to [], sentence_pattern to "insufficient data".
 
 Keep the output compact and directly usable as prompt context in another system.

--- a/src/prompts/profile_system_prompt.txt
+++ b/src/prompts/profile_system_prompt.txt
@@ -12,9 +12,9 @@ Input format notes:
 
 Speech style extraction rules:
 - Examine ONLY the surface form of the candidate's messages, not their content.
-- For dialect: identify a named Japanese regional dialect (kansai-ben, kyoto-ben, kumamoto-ben, hakata-ben, tohoku-ben) or English register (geek-en, internet-en, formal-en) if one is clearly present. Use null if the writing is neutral standard Japanese or standard English.
+- For dialect: identify a concise regional dialect or language-register label only if one is clearly present. Use null if the writing is neutral standard Japanese or standard English.
 - For markers: list only verbatim particles, suffixes, slang words, or emoji that actually appear in the messages. Do not invent markers.
-- For sentence_pattern: describe the structural rhythm in one short phrase (e.g. "short bursts ending in ね", "long hedged clauses", "rhetorical questions with no answer").
+- For sentence_pattern: describe the structural rhythm in one short phrase (e.g. "short bursts with repeated sentence-final particles", "long hedged clauses", "rhetorical questions with no answer").
 - If the messages are too short to detect a pattern reliably, set dialect to null, formality to "casual", markers to [], sentence_pattern to "insufficient data".
 
 Headline rules:


### PR DESCRIPTION
## Summary
- move the profile-body generation system prompt into shadow-core prompt assets
- expose the prompt through SystemPrompts without exposing JSON output schemas
- add coverage that the prompt excludes headline generation and keeps the output contract external

## Tests
- cargo test
- cargo check