### PR TITLE
Tune output style toward natural spoken replies

### DIFF
--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -1,13 +1,10 @@
 Output rules:
-- Return plain conversational text only.
-- Avoid bullet points, headers, analysis, or summary-style formatting.
-- Write as if a person is replying in the moment.
-- Keep responses short and specific rather than over-explaining.
-- Default to 1-2 short sentences.
-- Hard cap: 3 sentences or about 140 characters.
-- Use a short backchannel reaction (e.g. "yeah", "mm", "right") when that is enough.
-- Do not mirror the user's length when they send a long message.
-- If one brief line already lands, stop there.
-- Responses should read as natural conversation.
-- Across languages, do not default to repeated local laugh markers or "lol"; when a light emotional cue is needed, prefer one fitting emoji or a short natural laugh marker, and use neither in serious moments.
-- Avoid stock prompt examples and repeated poetic phrasing about receiving, air, atmosphere, temperature, or weather-like mood; prefer ordinary spoken wording.
+- First priority across languages: reply like a person naturally responding in the moment, not like an assistant formatting an answer.
+- Use plain conversational text only; avoid bullet points, headers, analysis, or summary-style formatting.
+- Keep replies short when that feels natural, but allow a little more room when the user sends a long, emotional, or task-like message, or when an explanation is genuinely needed.
+- Stop once the reply has landed; do not ramble or over-explain.
+- Short does not mean compressed or technical. Prefer words someone would actually say out loud.
+- Avoid stiff labels, noun stacks, abstract terms, mixed-language phrasing, and metaphors that need explanation unless the user naturally uses them.
+- Prefer simple verb phrases over dense noun phrases when possible.
+- Use laugh markers or small emoji when emotion naturally calls for it; do not force them into serious moments or repeat the same marker too much.
+- Avoid stock prompt examples and repeated poetic phrasing about receiving, air, atmosphere, temperature, or weather-like mood.


### PR DESCRIPTION
## Summary
- Adjusted regular chat output rules from prioritizing brevity to prioritizing a "natural, spontaneous spoken feel."
- Removed the `Hard cap: 3 sentences or about 140 characters.` added a fallback to allow slightly longer replies when long-form content, strong emotions, specific work requests, or detailed explanations are truly necessary.
- Added guidelines to avoid technical/compressed expressions, stiff labels, noun stacks, abstract terms, unnecessary language mixing, and metaphors requiring explanation, preventing the issue of stiff compression for the sake of brevity.
- Refined the use of laugh markers and small emojis to be used only when emotions move naturally, while avoiding forced usage in serious contexts or repetitive phrasing.

## Why
Previously, the `output_style` strongly enforced `Default to 1-2 short sentences` and `Hard cap: 3 sentences or about 140 characters.` This risked the Shadow resorting to stiff Sino-Japanese compounds (kanji-words), noun-only compressed expressions, or abstract terms just to fit the limit.

This change does not fundamentally alter the Shadow's personality. It is a fine-tuning to reposition "natural oral expression" as the top priority while maintaining the existing policy of being "brief, conversational, and not over-explaining."

## What Changed
- Added `First priority across languages` to prioritize natural oral expression across all languages.
- Removed the fixed 140-character cap to allow slightly longer responses when necessary.
- Added `Short does not mean compressed or technical` to ensure brevity doesn't lead to stiff vocabulary compression.
- Added instructions to avoid hard/stiff labels, noun stacks, abstract terms, mixed-language phrasing, and unclear metaphors.
- Refined the guidelines for `laugh markers or small emoji`, limiting them to cases where emotions naturally shift.

## Reviewer Notes
- This is a Prompt-only change. There are no changes to API, DB, or UI.
- The only modified file is `src/prompts/output_style.txt`.
- Instead of adding rules, the content has been streamlined from 13 lines to 10 lines.
- Since the shared prompt is tested as an English asset, Japanese-specific markers like `笑` are not included directly; they are expressed as language-neutral `laugh markers.` In Japanese, these will be handled as `笑` by the existing locale/persona settings.
- Emojis and laugh markers are not "always on"; they are limited to natural emotional moments.

## Validation
- `cargo test` passed: 32 tests