### PR TITLE
refactor: move generic shadow types into shadow-core

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod drop_seed;
 mod pair_topic;
 mod prompt_inputs;
 mod template;
+mod types;
 
 pub use drop_seed::{render_drop_definitions_for_locale, DropDefinition, DROP_DEFINITIONS};
 pub use pair_topic::{
@@ -10,9 +11,12 @@ pub use pair_topic::{
 };
 pub use prompt_inputs::{
     PairShadowIdentity, PromptReadyPersona, PromptReadyProfile, PromptReadyReasoningPolicy,
-    PromptReadySpeechStyle,
+    SpeechStyle,
 };
 pub use template::PromptTemplate;
+pub use types::{
+    GenerationEngine, ShadowAnswer, ShadowAnswerContent, ShadowGenerationFailure, ShadowProfile,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LocalePhrases {

--- a/src/prompt_inputs.rs
+++ b/src/prompt_inputs.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PromptReadySpeechStyle {
+pub struct SpeechStyle {
     pub dialect: Option<String>,
     pub formality: String,
     pub markers: Vec<String>,
@@ -20,7 +20,7 @@ pub struct PromptReadyPersona {
     pub tone: String,
     pub traits: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub speech_style: Option<PromptReadySpeechStyle>,
+    pub speech_style: Option<SpeechStyle>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,4 +38,76 @@ pub struct PairShadowIdentity {
     pub persona: Option<PromptReadyPersona>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_policy: Option<PromptReadyReasoningPolicy>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PairShadowIdentity, PromptReadyPersona, PromptReadyProfile, PromptReadyReasoningPolicy};
+    use crate::{ShadowAnswer, ShadowAnswerContent, ShadowProfile, SpeechStyle};
+
+    #[test]
+    fn shadow_profile_serializes_as_flat_core_type() {
+        let profile = ShadowProfile {
+            headline: "Answers with explicit tradeoffs".to_string(),
+            stance: "evidence_first".to_string(),
+            source_answers: vec!["I value responsibility".to_string()],
+            tone: "reflective".to_string(),
+            traits: vec!["structured".to_string()],
+            decision_style: "principled_tradeoff".to_string(),
+            anchor: "evidence before action".to_string(),
+            speech_style: Some(SpeechStyle {
+                dialect: Some("kansai-ben".to_string()),
+                formality: "casual".to_string(),
+                markers: vec!["やん".to_string()],
+                sentence_pattern: "short bursts ending in やん".to_string(),
+            }),
+        };
+
+        let value = serde_json::to_value(profile).expect("shadow profile should serialize");
+        assert_eq!(value["headline"], "Answers with explicit tradeoffs");
+        assert_eq!(value["tone"], "reflective");
+        assert_eq!(value["speech_style"]["formality"], "casual");
+    }
+
+    #[test]
+    fn pair_shadow_identity_uses_renamed_speech_style_type() {
+        let identity = PairShadowIdentity {
+            name: "Kage".to_string(),
+            profile: Some(PromptReadyProfile {
+                headline: "clear".to_string(),
+                stance: "measured".to_string(),
+                source_answers: vec!["One".to_string()],
+            }),
+            persona: Some(PromptReadyPersona {
+                tone: "warm".to_string(),
+                traits: vec!["curious".to_string()],
+                speech_style: Some(SpeechStyle {
+                    dialect: None,
+                    formality: "neutral".to_string(),
+                    markers: vec!["hmm".to_string()],
+                    sentence_pattern: "short".to_string(),
+                }),
+            }),
+            reasoning_policy: Some(PromptReadyReasoningPolicy {
+                decision_style: "evidence_first".to_string(),
+                anchor: "signal".to_string(),
+            }),
+        };
+
+        let value = serde_json::to_value(identity).expect("pair identity should serialize");
+        assert_eq!(value["persona"]["speech_style"]["formality"], "neutral");
+    }
+
+    #[test]
+    fn shadow_answer_final_text_keeps_title_and_body_format() {
+        let answer = ShadowAnswer {
+            content: ShadowAnswerContent {
+                title: "A title".to_string(),
+                body: "A body".to_string(),
+            },
+            display_deltas: vec!["A title".to_string()],
+        };
+
+        assert_eq!(answer.content.final_answer_text(), "A title\n\nA body");
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShadowProfile {
+    pub headline: String,
+    pub stance: String,
+    pub source_answers: Vec<String>,
+    pub tone: String,
+    pub traits: Vec<String>,
+    pub decision_style: String,
+    pub anchor: String,
+    #[serde(default)]
+    pub speech_style: Option<crate::SpeechStyle>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowAnswerContent {
+    pub title: String,
+    pub body: String,
+}
+
+impl ShadowAnswerContent {
+    #[must_use]
+    pub fn final_answer_text(&self) -> String {
+        if self.body.trim().is_empty() {
+            self.title.trim().to_string()
+        } else {
+            format!("{}\n\n{}", self.title.trim(), self.body.trim())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowAnswer {
+    pub content: ShadowAnswerContent,
+    pub display_deltas: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationEngine {
+    pub provider: &'static str,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowGenerationFailure {
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for ShadowGenerationFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ShadowGenerationFailure {}


### PR DESCRIPTION
## Summary
- move canonical shadow profile/answer/generation types into `shadow-core`
- rename `PromptReadySpeechStyle` to `SpeechStyle` and re-export the new type surface
- keep app-side persona routing outside the core crate so the parent app can consume it as optional metadata

## Related Issue
- Supports enigmatch/shadow-based-testing#777

## Changes
- add `src/types.rs` for reusable shadow domain types
- update `lib.rs` exports to expose the new core surface
- update prompt input code to use the `SpeechStyle` rename

## Validation
- parent repo focused regression tests against the new core type surface
