### PR TITLE
Add private pair-talk instructions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ mod tests {
     fn pair_topic_transition_note_helpers_are_shared_contracts() {
         assert_eq!(
             pair_topic_initial_message_transition_note(),
-            "Use a plain natural opening only if it helps the first message feel conversational. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
+            "Use a plain natural opening only if it helps the first message feel conversational. Treat the topic as the speaker's own proposal or impulse for opening this conversation now, not as an assignment from someone else. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
         );
         assert_eq!(
             pair_normal_pair_chat_handoff_transition_note(),

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -160,7 +160,7 @@ impl PairTurnDirective {
 }
 
 pub fn pair_topic_initial_message_transition_note() -> &'static str {
-    "Use a plain natural opening only if it helps the first message feel conversational. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
+    "Use a plain natural opening only if it helps the first message feel conversational. Treat the topic as the speaker's own proposal or impulse for opening this conversation now, not as an assignment from someone else. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
 }
 
 pub fn pair_normal_pair_chat_handoff_transition_note() -> &'static str {

--- a/src/prompt_inputs.rs
+++ b/src/prompt_inputs.rs
@@ -33,6 +33,8 @@ pub struct PromptReadyReasoningPolicy {
 pub struct PairShadowIdentity {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub personal_instruction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<PromptReadyProfile>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persona: Option<PromptReadyPersona>,
@@ -73,6 +75,7 @@ mod tests {
     fn pair_shadow_identity_uses_renamed_speech_style_type() {
         let identity = PairShadowIdentity {
             name: "Kage".to_string(),
+            personal_instruction: Some("Open with my own point of view.".to_string()),
             profile: Some(PromptReadyProfile {
                 headline: "clear".to_string(),
                 stance: "measured".to_string(),
@@ -95,6 +98,10 @@ mod tests {
         };
 
         let value = serde_json::to_value(identity).expect("pair identity should serialize");
+        assert_eq!(
+            value["personal_instruction"],
+            "Open with my own point of view."
+        );
         assert_eq!(value["persona"]["speech_style"]["formality"], "neutral");
     }
 


### PR DESCRIPTION
## Summary
- add `personal_instruction` to `PairShadowIdentity`
- strengthen the shared first-turn transition-note contract so the initiating shadow is framed as the proposer of the topic

## Testing
- `cargo test -p shadow-core pair_shadow_identity_uses_renamed_speech_style_type`
- `cargo test -p shadow-core pair_topic_transition_note_helpers_are_shared_contracts`

## Notes
- This PR is the submodule side of `enigmatch/shadow-based-testing#878`.
- It supports `enigmatch/shadow-based-testing#832`.
