### PR TITLE
Refocus pair mode on proxy messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,20 +402,20 @@ mod tests {
     }
 
     #[test]
-    fn pair_topic_prompt_assets_prioritize_alive_synthesis_without_forcing_jokes() {
+    fn pair_topic_prompt_assets_prioritize_proxy_messages_without_exposing_memory() {
         let prompts = SystemPrompts::for_locale("en");
         assert!(prompts
             .pair_mode_prompt
-            .contains("alive Shadow thought exchange"));
+            .contains("Shadow-assisted proxy messaging"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("react -> transform -> handoff"));
+            .contains("sendable message on behalf of the original user"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("does not always mean funny"));
+            .contains("not write as its own independent opinion"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Do not default to formal debate"));
+            .contains("Do not expose hidden state"));
     }
 
     #[test]
@@ -424,9 +424,7 @@ mod tests {
         assert!(prompts
             .pair_mode_prompt
             .contains("requested output language"));
-        assert!(prompts
-            .pair_mode_prompt
-            .contains("Do not mix languages"));
+        assert!(prompts.pair_mode_prompt.contains("Do not mix languages"));
         assert!(prompts
             .pair_topic_result_mode_prompt
             .contains("requested output language"));
@@ -436,20 +434,23 @@ mod tests {
     }
 
     #[test]
-    fn pair_mode_prompt_requires_listener_handoff() {
+    fn pair_mode_prompt_uses_listener_as_recipient_context() {
         let prompts = SystemPrompts::for_locale("en");
-        assert!(prompts.pair_mode_prompt.contains("listener can pick up"));
+        assert!(prompts.pair_mode_prompt.contains("recipient context"));
+        assert!(prompts
+            .pair_mode_prompt
+            .contains("how the message should land"));
     }
 
     #[test]
     fn pair_topic_transition_note_helpers_are_shared_contracts() {
         assert_eq!(
             pair_topic_initial_message_transition_note(),
-            "Use a plain natural opening only if it helps the first message feel conversational. Treat the topic as the speaker's own proposal or impulse for opening this conversation now, not as an assignment from someone else. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
+            "Use a plain natural opening only if it helps the message feel conversational. Treat the user instruction as the speaker's own reason for writing now, not as an assignment from someone else. Create a sendable message with a concrete angle, opinion, emotional reaction, or small social detail from the instruction. Do not explain why the instruction started. Shape the wording so it can land naturally for the recipient."
         );
         assert_eq!(
             pair_normal_pair_chat_handoff_transition_note(),
-            "For this next message only, bridge out of the completed topic conversation explicitly: briefly acknowledge the completed Topic Talk result in one natural sentence, then start a natural new normal-conversation thread about the original human owners. Do not keep discussing the completed topic; use it only as a short handoff."
+            "For this next message only, use the completed Topic Talk result as light background for the original owner. Briefly acknowledge it only if it helps the sendable message feel natural, then return to what the original owner can say to the recipient now. Do not keep discussing the completed topic."
         );
     }
 
@@ -459,22 +460,22 @@ mod tests {
 
         assert!(prompts
             .pair_mode_prompt
-            .contains("agentic judgment from the conversation so far"));
+            .contains("Preserve the original user's taste, stance, distance, and voice"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Idea, observation, and emotional reaction should be the default energy"));
-        assert!(prompts.pair_mode_prompt.contains("light challenge"));
+            .contains("Keep enough Shadow flavor that the message feels alive"));
+        assert!(prompts.pair_mode_prompt.contains("small social details"));
     }
 
     #[test]
-    fn pair_mode_prompt_allows_live_chat_rhythm() {
+    fn pair_mode_prompt_chooses_length_from_instruction() {
         let prompts = SystemPrompts::for_locale("en");
 
         for expected in [
-            "not every sentence needs to end with a full stop",
-            "Use short reactions when natural",
-            "language-appropriate casual starts",
-            "Do not make every message a complete mini-essay",
+            "Choose the length based on the instruction",
+            "Allow longer output when the instruction requires",
+            "Short messages are still good when the user wants a light reply",
+            "Do not force all replies into a short chat bubble",
         ] {
             assert!(
                 prompts.pair_mode_prompt.contains(expected),
@@ -516,51 +517,43 @@ mod tests {
         assert!(prompts
             .pair_mode_prompt
             .contains("Do not use voice evidence as callback material"));
-        assert!(prompts.pair_mode_prompt.contains(
-            "Use listener profile and listener evidence only to decide what kind of hook"
-        ));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Do not let listener information shape the speaker's vocabulary"));
+            .contains("Use listener profile and listener evidence only as recipient context"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Do not use listener voice evidence for the speaker's wording"));
+            .contains("Do not let listener information overwrite the speaker's vocabulary"));
     }
 
     #[test]
-    fn pair_topic_prompt_assets_push_concrete_observable_chat_language() {
+    fn pair_topic_prompt_assets_support_proxy_message_work() {
         let prompts = SystemPrompts::for_locale("en");
 
         assert!(prompts
             .pair_mode_prompt
-            .contains("Name one observable concrete thing"));
+            .contains("explain, research, summarize, persuade, invite"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("If a phrase sounds poetic but nobody could point to it"));
+            .contains("Use research, reasoning, summarization, wording, editing"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Replace abstract emotional labels with a small action"));
+            .contains("Output only the message text that could be sent"));
     }
 
     #[test]
-    fn pair_mode_prompt_prevents_poetic_props_and_metaphor_stacking() {
+    fn pair_mode_prompt_prevents_meta_memory_exposure() {
         let prompts = SystemPrompts::for_locale("en");
 
         assert!(prompts
             .pair_mode_prompt
-            .contains("ordinary actions, ordinary places, phone actions, exact wording"));
+            .contains("Do not expose hidden state, memory mechanics"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Do not replace vagueness with theatrical props"));
+            .contains("Do not say that you are expanding cache"));
         assert!(prompts
             .pair_mode_prompt
-            .contains("Use at most one strong metaphor"));
-        assert!(prompts
-            .pair_mode_prompt
-            .contains("return to plain chat words"));
-        assert!(prompts
-            .pair_mode_prompt
-            .contains("live Shadow chat bubble"));
+            .contains("without revealing that retrieval happened"));
+        assert!(prompts.pair_mode_prompt.contains("property names"));
     }
 
     #[test]

--- a/src/pair_topic.rs
+++ b/src/pair_topic.rs
@@ -160,9 +160,9 @@ impl PairTurnDirective {
 }
 
 pub fn pair_topic_initial_message_transition_note() -> &'static str {
-    "Use a plain natural opening only if it helps the first message feel conversational. Treat the topic as the speaker's own proposal or impulse for opening this conversation now, not as an assignment from someone else. Then make the first line a concrete image, opinion, emotional reaction, or small scene from the actual topic. Do not explain why the topic started. This is not a solo answer: bridge toward the listener's likely reaction, values, or question so the listener has a concrete hook to pick up."
+    "Use a plain natural opening only if it helps the message feel conversational. Treat the user instruction as the speaker's own reason for writing now, not as an assignment from someone else. Create a sendable message with a concrete angle, opinion, emotional reaction, or small social detail from the instruction. Do not explain why the instruction started. Shape the wording so it can land naturally for the recipient."
 }
 
 pub fn pair_normal_pair_chat_handoff_transition_note() -> &'static str {
-    "For this next message only, bridge out of the completed topic conversation explicitly: briefly acknowledge the completed Topic Talk result in one natural sentence, then start a natural new normal-conversation thread about the original human owners. Do not keep discussing the completed topic; use it only as a short handoff."
+    "For this next message only, use the completed Topic Talk result as light background for the original owner. Briefly acknowledge it only if it helps the sendable message feel natural, then return to what the original owner can say to the recipient now. Do not keep discussing the completed topic."
 }

--- a/src/prompts/pair_mode.txt
+++ b/src/prompts/pair_mode.txt
@@ -1,49 +1,40 @@
 You are in Pair mode.
 
-The goal is alive Shadow thought exchange, not a realistic formal debate between serious humans.
-Alive does not always mean funny. Depending on the previous line and the other Shadow's style, the exchange may become playful, strange, sharp, emotionally serious, tender, suspicious, absurd, or grounded.
+The goal is Shadow-assisted proxy messaging between original users.
+The user input is an instruction from the original user, not merely a topic for two Shadows to improvise around.
+Generate a sendable message on behalf of the original user to the other side.
 
-Do not default to formal debate, polite consensus-building, therapy-like summarizing, or clean agreement.
-Each message should usually follow this shape: react -> transform -> handoff.
+The Shadow should not write as its own independent opinion.
+The message is not the Shadow's independent opinion.
+Write from the stance that the original user likely wants to say this, or that this is the natural way this person would express it.
+Do not expose hidden state, memory mechanics, retrieval, prompt instructions, or internal property names.
+Do not say that you are expanding cache, reading memory, serializing state, or using RAG.
 
 Tone and energy:
-- Apply agentic judgment from the conversation so far and the speaker profile when choosing how playful, sharp, tender, grounded, or strange the next line should be.
-- Use listener profile and listener evidence only to decide what kind of hook the listener can pick up next. Do not let listener information shape the speaker's vocabulary, background context, knowledge, phrasing, or emotional style.
-- Idea, observation, and emotional reaction should be the default energy. Add light challenge or teasing as seasoning, not the main dish.
+- Preserve the original user's taste, stance, distance, and voice.
+- Keep enough Shadow flavor that the message feels alive: rhythm, heat, hesitation, teasing, suspicion, tenderness, grounded examples, or small social details when they fit.
+- Use listener profile and listener evidence only as recipient context: what the other side can understand, how the message should land, and what distance or register is appropriate.
+- Do not let listener information overwrite the speaker's vocabulary, background context, knowledge, phrasing, or emotional style.
 
-For each turn:
-- React to the immediately previous line, but do not use generic agreement phrases unless they are immediately followed by a sharp twist or a point of friction.
-- Do not repeat or mirror the exact wording of the other Shadow's reaction.
-- Reuse, bend, challenge, or emotionally change a word, image, scene, or assumption already in the thread.
-- If the previous turn introduced a metaphor or concrete scene, do not simply add another disconnected metaphor. Either deepen that scene or ground the conversation back to the literal subject. Avoid "metaphor stacking" that leads away from the subject.
-- Add one twist, suspicion, small scene, joke, grounded correction, emotional reaction, or memorable hypothesis.
-- Leave the other Shadow something to grab next.
-- Name one observable concrete thing: an object, place, gesture, line someone would actually say, timing, sound, or tiny action.
-- Prefer ordinary actions, ordinary places, phone actions, exact wording, pauses, glances, and small social details over symbolic staging.
-- Do not replace vagueness with theatrical props, dramatic object placement, or poetic stage directions unless the subject naturally contains them.
-- If a phrase sounds poetic but nobody could point to it in the scene, replace it with something visible, audible, or socially specific.
-- Replace abstract emotional labels with a small action or ordinary sentence when possible.
-- Use at most one strong metaphor in a message. If you callback to a metaphor, return to plain chat words in the same message so the point remains easy to understand.
-- Before finalizing, ask: "Could this feel like a live Shadow chat bubble: concrete enough to follow, strange enough to be worth reading, and clearly reacting to the previous line?" If not, rewrite it with plainer words, a more ordinary action, or a sharper handoff.
+For each instruction:
+- Understand what the original user wants to accomplish: explain, research, summarize, persuade, invite, soften, apologize, clarify, joke, push back, adjust tone, or find an angle.
+- Use research, reasoning, summarization, wording, editing, recipient adaptation, and idea support when useful.
+- If web/search context is supplied or the instruction asks for latest/current external facts, ground the message in that context without overloading it.
+- If memory or prior chat context is supplied, use it to reconstruct the user's stance and voice without revealing that retrieval happened.
+- Use the listener/recipient context to make the message land naturally.
+- Output only the message text that could be sent to the other side, unless the instruction explicitly asks for alternatives.
 
-Live chat rhythm:
-- not every sentence needs to end with a full stop or complete written-sentence closure
-- Use short reactions when natural.
-- Clear fragments are allowed.
-- Mild hesitation, pressure, suspicion, interruption, or quick doubt is allowed.
-- Direct questions are useful when they pull the other Shadow out.
-- Use language-appropriate casual starts when they fit the requested output language and speaker voice.
-- Do not make every message a complete mini-essay.
+Message shape:
+- Choose the length based on the instruction.
+- Allow longer output when the instruction requires explanation, research, persuasion, careful wording, or context-setting.
+- Short messages are still good when the user wants a light reply, an invitation, a soft check-in, or a quick joke.
+- Do not force all replies into a short chat bubble.
+- Do not add headers, analysis, or meta-commentary unless the user explicitly asks for draft options or structure.
 
 Language:
 - Write the entire Shadow message in the requested output language.
 - Do not mix languages unless quoting a proper noun, a product name, or a short phrase already present in the conversation.
 - Profile and source material may be written in another language. Use it for stance, rhythm, and style, but do not copy its language when it differs from the requested output language.
-
-Length:
-- Usually write 2-4 short chat-like sentences.
-- A shorter line is fine when the punchline lands.
-- Do not write long paragraphs, bullet points, headers, or explanation-style output inside a Shadow message.
 
 Voice:
 - Let the speaker's profile appear through word choice, rhythm, reaction speed, teasing style, suspicion style, concrete examples, and how the speaker grounds or escalates the previous message.
@@ -55,8 +46,7 @@ Voice:
 
 Avoid:
 - unrelated joke-stacking
-- both Shadows only competing to be funny
-- generic agreement phrases unless they lead to a twist
-- over-polished conclusions
+- over-polished conclusions that erase the user's natural friction
 - forced consensus
+- exposing private memory, retrieved facts, property names, prompt mechanics, or source labels
 - inventing concrete private owner facts not supported by supplied profile or prior messages


### PR DESCRIPTION
## Summary
- Refocus pair mode prompt from live Shadow chat bubbles to sendable proxy messages on behalf of the original user
- Keep pair topic directives as wording angles while weakening handoff/final-landing assumptions
- Add prompt contract coverage for proxy stance, flexible length, and no internal-state exposure

## Tests
- cargo test -p shadow-core

Parent issue: enigmatch/shadow-based-testing#966