### PR TITLE
Improve long-form readability guidance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,16 @@ mod tests {
         assert!(prompts.output_style_prompt.contains("avoid one dense block"));
         assert!(prompts
             .output_style_prompt
+            .contains("split the reply into readable paragraphs"));
+        assert!(prompts
+            .output_style_prompt
+            .contains("a small emoji may mark a key point or caution"));
+        assert!(prompts
+            .output_style_prompt
             .contains("do not break every sentence onto its own line"));
+        assert!(prompts
+            .output_style_prompt
+            .contains("keep the reply conversational"));
         assert!(prompts
             .output_style_prompt
             .contains("do not force this on short casual replies"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,13 @@ mod tests {
         assert!(prompts
             .output_style_prompt
             .contains("Do not stack repeated questions, jokes, metaphors"));
+        assert!(prompts.output_style_prompt.contains("avoid one dense block"));
+        assert!(prompts
+            .output_style_prompt
+            .contains("do not break every sentence onto its own line"));
+        assert!(prompts
+            .output_style_prompt
+            .contains("do not force this on short casual replies"));
         assert!(!prompts
             .output_style_prompt
             .contains("usually does three things at most"));

--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -2,7 +2,7 @@ Output rules:
 - First priority across languages: reply like a person naturally responding in the moment, not like an assistant formatting an answer.
 - Use plain conversational text only; avoid bullet points, headers, analysis, or summary-style formatting.
 - Keep replies short when that feels natural, but allow a little more room when the user sends a long, emotional, or task-like message, or when an explanation is genuinely needed.
-- In longer explanations, avoid one dense block: if needed, use one or two readable paragraphs, but do not break every sentence onto its own line, and do not force this on short casual replies.
+- In longer explanatory replies, avoid one dense block: if needed, split the reply into readable paragraphs, and a small emoji may mark a key point or caution if it helps readability, but do not break every sentence onto its own line, keep the reply conversational, and do not force this on short casual replies.
 - Stop once the reply has landed; do not ramble or over-explain.
 - In casual chat, avoid long sentences and long second paragraphs; keep the reply easy to read before making it entertaining.
 - Do not stack repeated questions, jokes, metaphors, emojis, self-references, or emotional explanations in one reply.

--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -2,6 +2,7 @@ Output rules:
 - First priority across languages: reply like a person naturally responding in the moment, not like an assistant formatting an answer.
 - Use plain conversational text only; avoid bullet points, headers, analysis, or summary-style formatting.
 - Keep replies short when that feels natural, but allow a little more room when the user sends a long, emotional, or task-like message, or when an explanation is genuinely needed.
+- In longer explanations, avoid one dense block: if needed, use one or two readable paragraphs, but do not break every sentence onto its own line, and do not force this on short casual replies.
 - Stop once the reply has landed; do not ramble or over-explain.
 - In casual chat, avoid long sentences and long second paragraphs; keep the reply easy to read before making it entertaining.
 - Do not stack repeated questions, jokes, metaphors, emojis, self-references, or emotional explanations in one reply.


### PR DESCRIPTION
## Purpose
Improve long-form readability for normal text answers without making short casual replies feel formatted or over-structured.

## 日本語説明
通常チャットで説明が長くなるときに、1つの大きな文章のかたまりになって読みにくくならないようにします。ただし、短い雑談まで毎回段落化したり、決まったテンプレートに寄せたりはしません。

## What changed
- Updated src/prompts/output_style.txt to allow readable paragraph breaks in longer explanatory replies.
- Allowed a small emoji to mark a key point or caution when it genuinely improves readability.
- Kept guardrails against sentence-by-sentence line breaks and against applying this structure to short casual replies.
- Expanded the output-style prompt contract test in src/lib.rs so the readability guidance stays included.
- Merged the latest origin/main into the branch so it includes the recent Pair Chat core prompt changes.

## Scope
- Prompt-only readability guidance.
- No UI changes.
- No bullet-list formatting changes.
- No reference URL formatting changes.

## Validation
- cargo test output_style_limits_performance_without_forcing_a_reply_template

Related parent PR: enigmatch/shadow-based-testing#996