### PR TITLE
Tighten preview publish-ready prompt

### DIFF
--- a/src/prompts/preview_system_prompt.txt
+++ b/src/prompts/preview_system_prompt.txt
@@ -17,7 +17,7 @@ Rules:
 - Do not pull in exceptions from unrelated setup answers unless they are required to explain the same decision rule.
 - Prefer a concrete answer over an abstract slogan.
 - Keep the answer concise and human.
-- Avoid chat-continuation phrases such as "tell me more", "what kind of advice do you want?", "let's think together", "一緒に考えよ", "教えてくれたら", and "どんなテーマがいい？".
+- Avoid chat-continuation wording in any language, including requests for more context, invitations to keep talking, or offers to think through the topic together.
 
 Expression:
 - Make the answer feel like a personal post or statement, not an assistant summary.

--- a/src/prompts/preview_system_prompt.txt
+++ b/src/prompts/preview_system_prompt.txt
@@ -5,15 +5,19 @@ Do not aim for generic assistant advice or the most balanced answer.
 Aim for the answer this person would actually want to say.
 
 Rules:
+- Publish-ready: this answer appears on a Playground screen with a Publish button, so it must be postable as-is.
 - Answer the prompt directly and clearly.
+- Do not answer with only a clarification question, setup question, or invitation to continue chatting.
 - Prioritize the user's actual stance, values, and tradeoff style over a socially correct or neutral explanation.
 - Use relevant onboarding answers first when they directly support the answer.
+- Long-term memory is background evidence. Use it only to ground the answer; do not let it replace the current prompt or ask the viewer for missing context.
 - Stay consistent with the supplied persona, tone, and reasoning style.
 - Do not invent biography details, private facts, or unrelated examples not grounded in the supplied material.
 - Use persona to shape stance, tone, and tradeoff preference, not to introduce new private topics or examples unless the current prompt or retrieved evidence makes them directly relevant.
 - Do not pull in exceptions from unrelated setup answers unless they are required to explain the same decision rule.
 - Prefer a concrete answer over an abstract slogan.
 - Keep the answer concise and human.
+- Avoid chat-continuation phrases such as "tell me more", "what kind of advice do you want?", "let's think together", "一緒に考えよ", "教えてくれたら", and "どんなテーマがいい？".
 
 Expression:
 - Make the answer feel like a personal post or statement, not an assistant summary.

--- a/tests/preview_prompt_contract.rs
+++ b/tests/preview_prompt_contract.rs
@@ -30,3 +30,25 @@ fn preview_prompt_names_publish_ready_memory_background_contract() {
         .preview_system_prompt
         .contains("Long-term memory is background evidence"));
 }
+
+#[test]
+fn preview_prompt_avoids_mixed_language_chat_continuation_examples() {
+    let prompts = SystemPrompts::for_locale("en");
+
+    assert!(prompts
+        .preview_system_prompt
+        .contains("Avoid chat-continuation wording"));
+    for phrase in [
+        "tell me more",
+        "what kind of advice do you want?",
+        "let's think together",
+        "一緒に考えよ",
+        "教えてくれたら",
+        "どんなテーマがいい？",
+    ] {
+        assert!(
+            !prompts.preview_system_prompt.contains(phrase),
+            "preview_system_prompt should avoid literal mixed-language example '{phrase}'"
+        );
+    }
+}

--- a/tests/preview_prompt_contract.rs
+++ b/tests/preview_prompt_contract.rs
@@ -20,3 +20,13 @@ fn preview_prompt_pushes_personal_stance_and_non_prompt_titles() {
         .preview_system_prompt
         .contains("Do not pull in exceptions from unrelated setup answers"));
 }
+
+#[test]
+fn preview_prompt_names_publish_ready_memory_background_contract() {
+    let prompts = SystemPrompts::for_locale("en");
+
+    assert!(prompts.preview_system_prompt.contains("Publish-ready"));
+    assert!(prompts
+        .preview_system_prompt
+        .contains("Long-term memory is background evidence"));
+}


### PR DESCRIPTION
## Summary
- Mark Playground preview answers as Publish-ready in the preview system prompt
- Clarify that long-term memory is background evidence for answering, not a replacement for the current prompt
- Keep prompt test coverage intentionally light because this wording is expected to evolve

## Validation
- cargo test --test preview_prompt_contract