### PR TITLE
Add previous_draft to PairComposePromptContext for adjust-based rewrite

### DIFF
--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -712,6 +712,8 @@ pub struct PairComposePromptContext<'a> {
     pub recent_messages: &'a [String],
     pub user_intent: &'a str,
     pub requested_output_language: &'a str,
+    /// Previously generated draft to refine. `None` means generate from scratch.
+    pub previous_draft: Option<&'a str>,
 }
 
 pub fn build_pair_compose_message_input(context: PairComposePromptContext<'_>) -> String {
@@ -747,6 +749,32 @@ pub fn build_pair_compose_message_input(context: PairComposePromptContext<'_>) -
     let actor_profile = pair_identity_block(context.actor);
     let listener_profile = pair_identity_block(context.listener);
 
+    let intent_block = match context.previous_draft {
+        None => format!(
+            "The user ({actor_name}) wants to say:\n{user_intent}\n\n\
+            Write a single message from {actor_name} to {listener_name} that expresses the above intent \
+            in {actor_name}'s authentic voice and personality. \
+            Make it natural, on-brand for {actor_name}, and appropriate for the conversation context. \
+            Do not add explanations or meta-commentary. \
+            Output only the message text in the requested output language.",
+            actor_name = context.actor.name,
+            listener_name = context.listener.name,
+            user_intent = context.user_intent,
+        ),
+        Some(draft) => format!(
+            "Current draft (written by {actor_name}):\n{draft}\n\n\
+            The user wants to adjust this draft as follows:\n{user_intent}\n\n\
+            Rewrite the draft applying the adjustment above. \
+            Preserve the draft's core substance and intent unless the adjustment explicitly asks to change it. \
+            Keep {actor_name}'s authentic voice and personality. \
+            Do not add explanations or meta-commentary. \
+            Output only the revised message text in the requested output language.",
+            actor_name = context.actor.name,
+            draft = draft,
+            user_intent = context.user_intent,
+        ),
+    };
+
     format!(
         "Actor Shadow profile:\n{actor_profile}\n\n\
         Listener Shadow profile:\n{listener_profile}\n\n\
@@ -757,12 +785,7 @@ pub fn build_pair_compose_message_input(context: PairComposePromptContext<'_>) -
         {reflection_block}\n\n\
         Recent conversation:\n{conversation}\n\n\
         Requested output language: {requested_output_language}\n\n\
-        The user ({actor_name}) wants to say:\n{user_intent}\n\n\
-        Write a single message from {actor_name} to {listener_name} that expresses the above intent \
-        in {actor_name}'s authentic voice and personality. \
-        Make it natural, on-brand for {actor_name}, and appropriate for the conversation context. \
-        Do not add explanations or meta-commentary. \
-        Output only the message text in the requested output language.",
+        {intent_block}",
         actor_profile = actor_profile,
         listener_profile = listener_profile,
         actor_voice_evidence = actor_voice_evidence,
@@ -772,9 +795,7 @@ pub fn build_pair_compose_message_input(context: PairComposePromptContext<'_>) -
         reflection_block = reflection_block,
         conversation = conversation,
         requested_output_language = context.requested_output_language,
-        user_intent = context.user_intent,
-        actor_name = context.actor.name,
-        listener_name = context.listener.name,
+        intent_block = intent_block,
     )
 }
 
@@ -880,4 +901,93 @@ fn persona_json(persona: &PromptReadyPersona) -> serde_json::Value {
 
 fn reasoning_policy_json(reasoning: &PromptReadyReasoningPolicy) -> serde_json::Value {
     serde_json::to_value(reasoning).expect("PromptReadyReasoningPolicy serialization is infallible")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PairShadowIdentity;
+
+    fn minimal_identity(name: &str) -> PairShadowIdentity {
+        PairShadowIdentity {
+            name: name.to_string(),
+            personal_instruction: None,
+            profile: None,
+            persona: None,
+            reasoning_policy: None,
+        }
+    }
+
+    fn base_context<'a>(
+        actor: &'a PairShadowIdentity,
+        listener: &'a PairShadowIdentity,
+        user_intent: &'a str,
+        previous_draft: Option<&'a str>,
+    ) -> PairComposePromptContext<'a> {
+        PairComposePromptContext {
+            actor,
+            listener,
+            actor_voice_evidence: &[],
+            relevant_onboarding_answers: &[],
+            onboarding_continuity: &[],
+            long_term_memory_block: "",
+            reflection_summaries: &[],
+            recent_messages: &[],
+            user_intent,
+            requested_output_language: "English",
+            previous_draft,
+        }
+    }
+
+    #[test]
+    fn without_draft_uses_fresh_compose_instruction() {
+        let actor = minimal_identity("Alice");
+        let listener = minimal_identity("Bob");
+        let input = build_pair_compose_message_input(base_context(&actor, &listener, "say hi", None));
+        assert!(
+            input.contains("The user (Alice) wants to say:\nsay hi"),
+            "fresh compose should use 'wants to say' framing"
+        );
+        assert!(
+            input.contains("Write a single message"),
+            "fresh compose should include standard write instruction"
+        );
+        assert!(
+            !input.contains("Current draft"),
+            "fresh compose should not mention a draft"
+        );
+    }
+
+    #[test]
+    fn with_draft_uses_rewrite_instruction() {
+        let actor = minimal_identity("Alice");
+        let listener = minimal_identity("Bob");
+        let draft = "Hey Bob! How's it going?";
+        let input = build_pair_compose_message_input(base_context(
+            &actor,
+            &listener,
+            "make it shorter",
+            Some(draft),
+        ));
+        assert!(
+            input.contains("Current draft (written by Alice):"),
+            "adjust compose should label the draft"
+        );
+        assert!(
+            input.contains(draft),
+            "adjust compose should include the draft text"
+        );
+        assert!(
+            input.contains("The user wants to adjust this draft as follows:\nmake it shorter"),
+            "adjust compose should frame user_intent as adjustment instruction"
+        );
+        assert!(
+            input.contains("Rewrite the draft"),
+            "adjust compose should instruct the LLM to rewrite"
+        );
+        assert!(
+            !input.contains("The user (Alice) wants to say:"),
+            "adjust compose should not use fresh-compose framing"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add `previous_draft: Option<&'a str>` field to `PairComposePromptContext`
- `build_pair_compose_message_input` branches on its presence: `None` uses the existing fresh-compose instruction, `Some(draft)` switches to a rewrite instruction that preserves the draft's core substance
- Two unit tests added in `knowledge::tests`

## Context
This is the shadow-core half of the fix for enigmatch/shadow-based-testing#1294 ([P0] Pair Chat Adjust should regenerate from the generated draft). The app-side PR is enigmatch/shadow-based-testing#1306.

## Changes
- `src/knowledge.rs`: `PairComposePromptContext` gains `previous_draft` field; `build_pair_compose_message_input` builds a conditional intent block based on whether a draft is present