### PR TITLE
Make SystemPrompts fields private; add public accessor functions

### DIFF
--- a/src/builders.rs
+++ b/src/builders.rs
@@ -113,6 +113,15 @@ pub fn requested_output_language(locale: &str) -> &'static str {
     ShadowLocale::from_code(ShadowLocale::resolve_code(locale)).prompt_language_name()
 }
 
+pub fn profile_system_prompt(locale: &str) -> &'static str {
+    SystemPrompts::for_locale(locale).profile_system_prompt
+}
+
+pub fn pair_topic_result_mode_prompt(locale: &str) -> &'static str {
+    SystemPrompts::for_locale(locale).pair_topic_result_mode_prompt
+}
+
+
 pub fn build_chat_system_prompt(shadow_name: &str, user_name: &str, locale: &str) -> String {
     build_chat_system_prompt_with_time_context(
         shadow_name,
@@ -300,8 +309,8 @@ mod tests {
         build_chat_system_prompt, build_chat_system_prompt_with_current_time,
         build_chat_system_prompt_with_time_context, build_onboarding_system_prompt,
         build_pair_compose_system_prompt, build_pair_topic_system_prompt_with_time_context,
-        preview_system_prompt, preview_system_prompt_with_context, requested_output_language,
-        PromptTimeContext,
+        pair_topic_result_mode_prompt, preview_system_prompt, preview_system_prompt_with_context,
+        profile_system_prompt, requested_output_language, PromptTimeContext,
     };
     use crate::LocalePhrases;
     use chrono::TimeZone;
@@ -651,6 +660,26 @@ mod tests {
             assert!(
                 prompt.contains("Do not switch languages because of"),
                 "preview prompt for {locale} must forbid switching to source-material language"
+            );
+        }
+    }
+
+    #[test]
+    fn profile_system_prompt_returns_non_empty_string_for_each_locale() {
+        for locale in ["en", "ja", "fr"] {
+            assert!(
+                !profile_system_prompt(locale).trim().is_empty(),
+                "profile_system_prompt must not be empty for locale '{locale}'"
+            );
+        }
+    }
+
+    #[test]
+    fn pair_topic_result_mode_prompt_returns_non_empty_string_for_each_locale() {
+        for locale in ["en", "ja", "fr"] {
+            assert!(
+                !pair_topic_result_mode_prompt(locale).trim().is_empty(),
+                "pair_topic_result_mode_prompt must not be empty for locale '{locale}'"
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@ pub use builders::{
     build_chat_system_prompt, build_chat_system_prompt_with_current_time,
     build_chat_system_prompt_with_time_context, build_onboarding_system_prompt,
     build_onboarding_system_prompt_with_time_context, build_pair_compose_system_prompt,
-    build_pair_topic_system_prompt_with_time_context, preview_system_prompt,
-    preview_system_prompt_with_context, requested_output_language, PromptTimeContext,
+    build_pair_topic_system_prompt_with_time_context, pair_topic_result_mode_prompt,
+    preview_system_prompt, preview_system_prompt_with_context, profile_system_prompt,
+    requested_output_language, PromptTimeContext,
 };
 pub use drop_seed::{render_drop_definitions_for_locale, DropDefinition, DROP_DEFINITIONS};
 pub use knowledge::{
@@ -90,17 +91,17 @@ impl LocalePhrases {
 }
 
 pub struct SystemPrompts {
-    pub profile_system_prompt: &'static str,
-    pub profile_body_system_prompt: &'static str,
-    pub preview_system_prompt: &'static str,
-    pub onboarding_turn_two_system_prompt: &'static str,
-    pub onboarding_turn_three_system_prompt: &'static str,
-    pub shadow_core_persona_prompt: &'static str,
-    pub onboarding_mode_prompt: &'static str,
-    pub normal_chat_mode_prompt: &'static str,
-    pub output_style_prompt: &'static str,
-    pub pair_mode_prompt: &'static str,
-    pub pair_topic_result_mode_prompt: &'static str,
+    profile_system_prompt: &'static str,
+    profile_body_system_prompt: &'static str,
+    preview_system_prompt: &'static str,
+    onboarding_turn_two_system_prompt: &'static str,
+    onboarding_turn_three_system_prompt: &'static str,
+    shadow_core_persona_prompt: &'static str,
+    onboarding_mode_prompt: &'static str,
+    normal_chat_mode_prompt: &'static str,
+    output_style_prompt: &'static str,
+    pair_mode_prompt: &'static str,
+    pair_topic_result_mode_prompt: &'static str,
 }
 
 impl SystemPrompts {

--- a/tests/preview_prompt_contract.rs
+++ b/tests/preview_prompt_contract.rs
@@ -1,43 +1,31 @@
-use shadow_core::SystemPrompts;
+use shadow_core::preview_system_prompt;
 
 #[test]
 fn preview_prompt_pushes_personal_stance_and_non_prompt_titles() {
-    let prompts = SystemPrompts::for_locale("en");
+    let prompt = preview_system_prompt("en");
 
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Aim for the answer this person would actually want to say."));
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Make the answer feel like a personal post or statement"));
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Do not use the title to restate, summarize, or lightly rephrase the prompt."));
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Keep the body answer to at most 2 sentences."));
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Do not pull in exceptions from unrelated setup answers"));
+    assert!(prompt.contains("Aim for the answer this person would actually want to say."));
+    assert!(prompt.contains("Make the answer feel like a personal post or statement"));
+    assert!(
+        prompt.contains("Do not use the title to restate, summarize, or lightly rephrase the prompt.")
+    );
+    assert!(prompt.contains("Keep the body answer to at most 2 sentences."));
+    assert!(prompt.contains("Do not pull in exceptions from unrelated setup answers"));
 }
 
 #[test]
 fn preview_prompt_names_publish_ready_memory_background_contract() {
-    let prompts = SystemPrompts::for_locale("en");
+    let prompt = preview_system_prompt("en");
 
-    assert!(prompts.preview_system_prompt.contains("Publish-ready"));
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Long-term memory is background evidence"));
+    assert!(prompt.contains("Publish-ready"));
+    assert!(prompt.contains("Long-term memory is background evidence"));
 }
 
 #[test]
 fn preview_prompt_avoids_mixed_language_chat_continuation_examples() {
-    let prompts = SystemPrompts::for_locale("en");
+    let prompt = preview_system_prompt("en");
 
-    assert!(prompts
-        .preview_system_prompt
-        .contains("Avoid chat-continuation wording"));
+    assert!(prompt.contains("Avoid chat-continuation wording"));
     for phrase in [
         "tell me more",
         "what kind of advice do you want?",
@@ -47,7 +35,7 @@ fn preview_prompt_avoids_mixed_language_chat_continuation_examples() {
         "どんなテーマがいい？",
     ] {
         assert!(
-            !prompts.preview_system_prompt.contains(phrase),
+            !prompt.contains(phrase),
             "preview_system_prompt should avoid literal mixed-language example '{phrase}'"
         );
     }


### PR DESCRIPTION
## Summary
- Remove `pub` from all `SystemPrompts` fields so internal prompt file changes are contained within shadow-core
- Add `profile_system_prompt(locale)` and `pair_topic_result_mode_prompt(locale)` as public accessor functions for the two fields used by the main repo
- Rewrite `tests/preview_prompt_contract.rs` to use the existing `preview_system_prompt()` function instead of direct field access

## Related Issue
- Close #68

## Changes
- `src/lib.rs` — remove `pub` from all `SystemPrompts` fields; re-export new accessor functions
- `src/builders.rs` — add `profile_system_prompt()`, `pair_topic_result_mode_prompt()`; add tests for both
- `tests/preview_prompt_contract.rs` — replace `SystemPrompts::for_locale(...).preview_system_prompt` with `preview_system_prompt()`

## How to do manual operation check
1. `cargo test` in shadow-core — 70/71 pass (1 pre-existing failure unrelated to this change)
2. Confirm the main repo compiles and tests pass after updating the submodule reference

## Validation
- [x] `cargo test` passes (pre-existing failure in `core_persona_prompts_include_sbt_instincts_without_db_overpromise` is unrelated)
- [ ] Verified key screens on mobile width

## Checklist
- [x] Followed `CONTRIBUTING.md`
- [x] No unnecessary placeholder/instructional UI copy
- [x] Added/updated tests for behavior changes
- [x] Kept commits small and scoped