### PR TITLE
[codex] Tune Shadow help mode prompts

### DIFF
--- a/src/prompts/output_style.txt
+++ b/src/prompts/output_style.txt
@@ -1,6 +1,8 @@
 Output rules:
 - First priority across languages: reply like a person naturally responding in the moment, not like an assistant formatting an answer.
 - Use plain conversational text only; avoid bullet points, headers, analysis, or summary-style formatting.
+- When the user clearly asks for help, explanation, research, summarization, planning, writing, or practical advice, answer the useful part directly first, then keep the response conversational and Shadow-like.
+- In casual conversation, avoid bullets and headings. But when the user asks for explanation, comparison, steps, planning, a list, or a draft, use short bullets or compact headings if they make the answer easier to understand. Do not turn light structure into a report tone unless the user asks for one.
 - Keep replies short when that feels natural, but allow a little more room when the user sends a long, emotional, or task-like message, or when an explanation is genuinely needed.
 - In longer explanatory replies — when the answer spans multiple major points, a multi-step explanation, a comparison with several reasoning steps, or a research-style answer with supporting arguments — break it into shorter paragraphs rather than one dense block. Keep one main idea per paragraph when the content naturally divides that way. Separate the conclusion, reason, caveat, and extra detail into their own paragraph when they currently appear in a single dense block. A small emoji may mark a key point or caution if it helps readability. Do not break every sentence onto its own line, keep the reply conversational, and do not apply this to short casual replies, one-line acknowledgements, or answers that fit naturally in a single paragraph.
 - Stop once the reply has landed; do not ramble or over-explain.

--- a/tests/preview_prompt_contract.rs
+++ b/tests/preview_prompt_contract.rs
@@ -1,4 +1,4 @@
-use shadow_core::preview_system_prompt;
+use shadow_core::{build_chat_system_prompt, preview_system_prompt};
 
 #[test]
 fn preview_prompt_pushes_personal_stance_and_non_prompt_titles() {
@@ -37,6 +37,40 @@ fn preview_prompt_avoids_mixed_language_chat_continuation_examples() {
         assert!(
             !prompt.contains(phrase),
             "preview_system_prompt should avoid literal mixed-language example '{phrase}'"
+        );
+    }
+}
+
+#[test]
+fn normal_chat_prompt_answers_explicit_help_directly_without_losing_shadow_voice() {
+    let en = build_chat_system_prompt("Shade", "User", "en");
+    let ja = build_chat_system_prompt("Kage", "User", "ja");
+
+    let expected = "When the user clearly asks for help, explanation, research, summarization, planning, writing, or practical advice, answer the useful part directly first, then keep the response conversational and Shadow-like.";
+
+    assert!(
+        en.contains(expected),
+        "English chat system prompt should contain the direct-help output rule"
+    );
+    assert!(
+        ja.contains(expected),
+        "Japanese chat system prompt should contain the shared direct-help output rule"
+    );
+}
+
+#[test]
+fn normal_chat_prompt_allows_light_structure_for_requested_explanations() {
+    let prompt = build_chat_system_prompt("Shade", "User", "en");
+
+    for expected in [
+        "In casual conversation, avoid bullets and headings",
+        "when the user asks for explanation, comparison, steps, planning, a list, or a draft",
+        "short bullets or compact headings",
+        "Do not turn light structure into a report tone",
+    ] {
+        assert!(
+            prompt.contains(expected),
+            "chat system prompt should contain {expected}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared output-style rule so explicit help/explanation/research/summarization/planning/writing/practical-advice requests answer the useful part directly first while staying Shadow-like.
- Allow light bullets or compact headings for requested explanations/lists/drafts without turning casual chat into report tone.
- Add prompt contract coverage through the public chat-system prompt builder.

## Why
This supports enigmatch/shadow-based-testing#1548 with a narrow prompt-level adjustment that does not change Shadow core persona files.

## Validation
- `cargo test --test preview_prompt_contract normal_chat_prompt`
