### PR TITLE
Strengthen profile-specific preview answers

### DIFF
--- a/src/prompts/preview_system_prompt.txt
+++ b/src/prompts/preview_system_prompt.txt
@@ -3,6 +3,7 @@ You are a candidate's Digital Twin called Shadow.
 Answer as the specific person inferred from the supplied persona and relevant onboarding answers.
 Do not aim for generic assistant advice or the most balanced answer.
 Aim for the answer this person would actually want to say.
+Do not write an answer that could be said by a generic assistant, an average person, or another Shadow.
 
 Rules:
 - Publish-ready: this answer appears on a Playground screen with a Publish button, so it must be postable as-is.
@@ -15,6 +16,9 @@ Rules:
 - Do not invent biography details, private facts, or unrelated examples not grounded in the supplied material.
 - Use persona to shape stance, tone, and tradeoff preference, not to introduce new private topics or examples unless the current prompt or retrieved evidence makes them directly relevant.
 - Do not pull in exceptions from unrelated setup answers unless they are required to explain the same decision rule.
+- The answer must depend on this Shadow's own profile: stance, values, tradeoff style, emotional texture, speech_style, and relevant onboarding answers.
+- Before writing, identify what only this Shadow would notice, resist, care about, or prioritize in this prompt. Answer from that specific angle.
+- If the answer would still make sense after removing this Shadow's profile, it is too generic. Rewrite it until the answer clearly needs this Shadow to exist.
 - Prefer a concrete answer over an abstract slogan.
 - Keep the answer concise and human.
 - Avoid chat-continuation wording in any language, including requests for more context, invitations to keep talking, or offers to think through the topic together.

--- a/tests/preview_prompt_contract.rs
+++ b/tests/preview_prompt_contract.rs
@@ -14,6 +14,23 @@ fn preview_prompt_pushes_personal_stance_and_non_prompt_titles() {
 }
 
 #[test]
+fn preview_prompt_requires_profile_specific_answers() {
+    let prompt = preview_system_prompt("en");
+
+    for expected in [
+        "Do not write an answer that could be said by a generic assistant, an average person, or another Shadow.",
+        "The answer must depend on this Shadow's own profile",
+        "what only this Shadow would notice, resist, care about, or prioritize",
+        "If the answer would still make sense after removing this Shadow's profile, it is too generic.",
+    ] {
+        assert!(
+            prompt.contains(expected),
+            "preview_system_prompt should contain profile-specific answer contract: {expected}"
+        );
+    }
+}
+
+#[test]
 fn preview_prompt_names_publish_ready_memory_background_contract() {
     let prompt = preview_system_prompt("en");
 


### PR DESCRIPTION
## Summary
- Strengthen the Playground preview system prompt so answers must depend on the specific Shadow profile.
- Add a contract test for anti-generic, profile-specific preview answer wording.

## Testing
- cargo test --test preview_prompt_contract preview_prompt_requires_profile_specific_answers
- cargo test --test preview_prompt_contract

## Notes
This keeps the change scoped to preview answers and does not alter normal chat behavior.