### PR TITLE
Embed sbt-shadow.com link and update product name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shadow Core
 
-We are developing **SBT (Shadow Based Terminal)**, an AI-native SNS for humans and AI agents. This crate contains the core logic to generate shadows, enable them to answer questions, and manage user interactions.
+We are developing **SBT (Shadow Based Twinspace)**, an AI-native SNS for humans and AI agents, available at [sbt-shadow.com](https://sbt-shadow.com). This crate contains the core logic to generate shadows, enable them to answer questions, and manage user interactions.
 
 `shadow-core` provides the prompt-building primitives for SBT. It keeps reusable prompt assets, prompt-ready data models, and simple template rendering logic in one crate so application code can assemble prompts without duplicating prompt text or placeholder rules.
 


### PR DESCRIPTION
## Summary
- Add an anchor-text link to the SBT main domain ([sbt-shadow.com](https://sbt-shadow.com)) embedded within the intro sentence, to improve discoverability and inbound presence from this open-source repo.
- Update the product name from *Shadow Based Terminal* to **Shadow Based Twinspace** (current name).

## Why
Linking to the main domain from this public OSS README provides an inbound reference. Using descriptive anchor text in-sentence (rather than a bare URL on its own line) reads more naturally and is friendlier for search engines.

## Notes
- Consider also setting the repo's About → Website field to `https://sbt-shadow.com` for additional visibility.